### PR TITLE
#CDD-772: Dynamic chart sizes

### DIFF
--- a/src/api/requests/charts/getCharts.ts
+++ b/src/api/requests/charts/getCharts.ts
@@ -3,9 +3,12 @@ import { api } from '@/api/api-utils'
 import { getApiBaseUrl } from '../helpers'
 import { Topics, Metrics, ChartTypes, FileFormats, Geography, GeographyType } from '@/api/models'
 import { logger } from '@/lib/logger'
+import { chartSizes, chartFormat } from '@/styles/Theme'
 
 export const requestSchema = z.object({
   file_format: z.optional(FileFormats),
+  chart_height: z.number(),
+  chart_width: z.number(),
   plots: z.array(
     z.object({
       topic: Topics,
@@ -22,9 +25,16 @@ export const requestSchema = z.object({
 
 export const responseSchema = z.string()
 
-type RequestParams = z.infer<typeof requestSchema>
+export type RequestParams = z.infer<typeof requestSchema>
 
-export const getCharts = async (json: RequestParams) => {
+export const getCharts = async (plots: RequestParams['plots'], size: 'narrow' | 'wide' = 'narrow') => {
+  const json: RequestParams = {
+    plots,
+    chart_width: chartSizes[size].width,
+    chart_height: chartSizes[size].height,
+    file_format: chartFormat,
+  }
+
   try {
     const res = await api.post(`${getApiBaseUrl()}/charts/v2`, { json }).text()
     return responseSchema.safeParse(res)

--- a/src/api/requests/cms/extractAndFetchPageData.ts
+++ b/src/api/requests/cms/extractAndFetchPageData.ts
@@ -31,12 +31,16 @@ export const extractAndFetchPageData = async (body: Body) => {
           if (column.type === 'chart_with_headline_and_trend_card' || column.type === 'chart_card') {
             const { chart } = column.value
 
+            // Calculate the chart size based on the number of columns (max num of 2)
+            const chartSize = content.value.columns.length === 1 ? 'wide' : 'narrow'
+
             // Pick out chart data for the chart and tabular data requests
             charts.push([
               `${column.id}-charts`,
-              getCharts({
-                plots: chart.map((plots) => plots.value),
-              }),
+              getCharts(
+                chart.map((plots) => plots.value),
+                chartSize
+              ),
             ])
 
             // Currently, the BE only supports showing single chart plots in tabular form

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -6,3 +6,16 @@ export const COLOURS = {
   BLUE_DARK: '#003078',
   BUTTON_GREY: '#D9D9D9',
 } as const
+
+export const chartSizes = {
+  narrow: {
+    width: 435,
+    height: 220,
+  },
+  wide: {
+    width: 930,
+    height: 220,
+  },
+} as const
+
+export const chartFormat = 'svg' as const


### PR DESCRIPTION
# Description

<img width="1073" alt="image" src="https://github.com/UKHSA-Internal/winter-pressures-frontend/assets/456966/4a96efd7-1a67-4e93-8934-8e6336175ab2">

Adds dynamic chart sizing according to where a chart sits within the columns (1 col or 2 col)

Fixes #CDD-772

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests
- [ ] Cypress tests
- [x] Mobile responsiveness
- [x] Accessibility (i.e. Lighthouse audit)
- [x] Disabled JavaScript

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any styles in this change follow the 'STYLES.md' guide
- [x] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
