### PR TITLE
CDD-1176 - Added formatting to tables

### DIFF
--- a/config/i18n/formatters.js
+++ b/config/i18n/formatters.js
@@ -17,7 +17,7 @@ module.exports = (value, format) => {
   if (format === 'dateShort') return dayjs(value).format('D MMMM YYYY')
   if (format === 'monthAndYear') return dayjs(value).format('MMM YYYY')
   if (format === 'time') return dayjs(value).format('hh:mma')
-  if (format === 'number') return value.toLocaleString('en-GB')
+  if (format === 'number') return value.toLocaleString('en-GB', { maximumFractionDigits: 2 })
   if (format === 'lowerCaseFirstLetter') return value.charAt(0).toLowerCase() + value.slice(1)
   return value
 }

--- a/src/app/components/cms/Table/Table.spec.tsx
+++ b/src/app/components/cms/Table/Table.spec.tsx
@@ -40,6 +40,33 @@ getTableMock.mockResolvedValue({
         },
       ],
     },
+    {
+      reference: '2023-01-31',
+      values: [
+        {
+          label: 'Plot1',
+          value: 12345.6666,
+        },
+      ],
+    },
+    {
+      reference: '2022-02-28',
+      values: [
+        {
+          label: 'Plot1',
+          value: 600.049,
+        },
+      ],
+    },
+    {
+      reference: '2022-02-28',
+      values: [
+        {
+          label: 'Plot1',
+          value: 8392.6,
+        },
+      ],
+    },
   ],
 })
 
@@ -91,9 +118,12 @@ test('table with row data', async () => {
 
   const cells = getAllByRole('cell')
 
-  expect(cells).toHaveLength(2)
+  expect(cells).toHaveLength(5)
   expect(cells[0]).toHaveTextContent('12,630')
   expect(cells[1]).toHaveTextContent('9,360')
+  expect(cells[2]).toHaveTextContent('12,345.67')
+  expect(cells[3]).toHaveTextContent('600.05')
+  expect(cells[4]).toHaveTextContent('8,392.6')
 })
 
 test('table api request fails', async () => {


### PR DESCRIPTION
# Description

Ensuring 2 decimal places on tabular formatted data

Fixes #CDD-1176

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
