### PR TITLE
Fix: multiple plots chart downloads

### DIFF
--- a/src/app/api/download/chart/route.ts
+++ b/src/app/api/download/chart/route.ts
@@ -9,14 +9,15 @@ export async function POST(req: NextRequest) {
 
   const body = await req.formData()
 
-  const plotsFormData = body.get('plots')
-
-  if (typeof plotsFormData !== 'string') {
-    return NextResponse.redirect(url, 301)
+  const plots = []
+  for (const [key, value] of body.entries()) {
+    if (key === 'plots') {
+      if (typeof value !== 'string') {
+        return NextResponse.redirect(url, 301)
+      }
+      plots.push(JSON.parse(value))
+    }
   }
-
-  const jsonPlots = JSON.parse(plotsFormData)
-  const plots = Array.isArray(jsonPlots) ? jsonPlots : [jsonPlots]
 
   const params = requestSchema.safeParse({
     file_format: body.get('format'),


### PR DESCRIPTION
# Description

- Since migrating to the `FormData` API our chart downloads endpoint has not been parsing multiple `plots` from the form submission. This fix makes sure we parse multiple plots correctly and feed them to the request handler