### PR TITLE
CDD-1737: Chart alt text update

### DIFF
--- a/e2e/fixtures/app.fixture.ts
+++ b/e2e/fixtures/app.fixture.ts
@@ -176,7 +176,7 @@ export class App {
   async hasTopicCard({ name, description }: { name: string; description: string }) {
     const card = this.page.getByRole('article', { name, exact: true })
     await expect(card.getByRole('paragraph')).toContainText(description)
-    await expect(card.getByAltText(`Chart showing ${description} Refer to tabular data below.`)).toBeVisible()
+    await expect(card.getByAltText(`Chart showing ${description} Refer to tabular data.`)).toBeVisible()
   }
 
   async hasRelatedLinks() {

--- a/e2e/fixtures/pages/home/home.fixture.ts
+++ b/e2e/fixtures/pages/home/home.fixture.ts
@@ -140,7 +140,7 @@ export class HomePage {
     await expect(card.getByText('722')).toBeVisible()
     await expect(card.getByText('-592 (-3%)')).toBeVisible()
     await expect(
-      card.getByAltText('Chart showing Positive tests reported in England Refer to tabular data below.')
+      card.getByAltText('Chart showing Positive tests reported in England Refer to tabular data.')
     ).toBeVisible()
 
     if (javaScriptEnabled) {
@@ -177,9 +177,7 @@ export class HomePage {
     await expect(card.getByText('379')).toBeVisible()
     await expect(card.getByText('21 (-5%)')).toBeVisible()
     await expect(
-      card.getByAltText(
-        'Chart showing Deaths with COVID-19 on the death certificate in England Refer to tabular data below.'
-      )
+      card.getByAltText('Chart showing Deaths with COVID-19 on the death certificate in England Refer to tabular data.')
     ).toBeVisible()
 
     if (javaScriptEnabled) {
@@ -229,7 +227,7 @@ export class HomePage {
     await expect(card.getByText('Last 7 days')).toBeVisible()
     await expect(card.getByText('0.26')).toBeVisible()
     await expect(
-      card.getByAltText('Chart showing Weekly hospital admission rates for Influenza Refer to tabular data below.')
+      card.getByAltText('Chart showing Weekly hospital admission rates for Influenza Refer to tabular data.')
     ).toBeVisible()
 
     if (javaScriptEnabled) {
@@ -262,7 +260,7 @@ export class HomePage {
     await expect(card.getByRole('heading', { level: 4, name: /Up to and including 10 May 2023/ })).toBeVisible()
     await expect(card.getByRole('tablist')).toBeVisible()
     await expect(card.getByRole('tab', { name: 'Chart' })).toHaveAttribute('aria-selected', 'true')
-    await expect(card.getByAltText('Chart showing Weekly positivity Refer to tabular data below.')).toBeVisible()
+    await expect(card.getByAltText('Chart showing Weekly positivity Refer to tabular data.')).toBeVisible()
 
     if (javaScriptEnabled) {
       await card.getByRole('tab', { name: 'Tabular data' }).click()

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -62,7 +62,7 @@
         "buttonDownloading": "Downloading"
       },
       "chart": {
-        "alt": "Chart showing {{- body}} Refer to tabular data below."
+        "alt": "Chart showing {{- body}} Refer to tabular data."
       }
     }
   },

--- a/src/app/components/cms/Chart/Chart.spec.tsx
+++ b/src/app/components/cms/Chart/Chart.spec.tsx
@@ -64,7 +64,7 @@ test('renders the chart correctly when successful', async () => {
     y_axis: null,
   })
 
-  expect(getByAltText('Chart showing COVID-19 chart description. Refer to tabular data below.')).toHaveAttribute(
+  expect(getByAltText('Chart showing COVID-19 chart description. Refer to tabular data.')).toHaveAttribute(
     'src',
     'data:image/svg+xml;utf8,mock-chart'
   )
@@ -119,7 +119,7 @@ test('renders the chart by geography and geography type when both are present in
     y_axis: null,
   })
 
-  expect(getByAltText('Chart showing COVID-19 chart description. Refer to tabular data below.')).toHaveAttribute(
+  expect(getByAltText('Chart showing COVID-19 chart description. Refer to tabular data.')).toHaveAttribute(
     'src',
     'data:image/svg+xml;utf8,mock-chart'
   )
@@ -146,7 +146,7 @@ test('full width charts should also have an acompanying narrow version for mobil
 
   const { getByAltText, getByTestId } = render((await Chart({ data, size: 'wide' })) as ReactElement)
 
-  expect(getByAltText('Chart showing COVID-19 chart description. Refer to tabular data below.')).toHaveAttribute(
+  expect(getByAltText('Chart showing COVID-19 chart description. Refer to tabular data.')).toHaveAttribute(
     'src',
     'data:image/svg+xml;utf8,mock-chart-narrow'
   )


### PR DESCRIPTION
# Description

- Remove the 'below' text in the alt description as it didn't make sense on Screen reader.