### PR TITLE
fix: rewrite url instead of redirect

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ const paths = {
 }
 
 export async function middleware(request: NextRequest) {
-  // Access our data redirects
+  // Access our data redirects/rewrites
   if (request.nextUrl.pathname === `/${paths.accessOurData}`) {
     try {
       const { id } = await getPageBySlug(paths.accessOurData, PageType.Composite)
@@ -35,7 +35,7 @@ export async function middleware(request: NextRequest) {
           },
         } = pages
 
-        return NextResponse.redirect(new URL(`/${paths.accessOurData}/${slug}`, request.url))
+        return NextResponse.rewrite(new URL(`/${paths.accessOurData}/${slug}`, request.url))
       }
       notFound()
     } catch (error) {


### PR DESCRIPTION
# Description

Navigating to access our data since #332 was merged presented a json response instead of the page. This response was the pre-fetch request that fires from the homepage for this page. We had this issue before when we first introduced CloudFront where it was caching pre-fetch requests and serving them instead of the actual page. We got around it by filtering out the `_rsc` query param from the CF cache as this is appended to all RSC prefetch requests. The redirect added in #332 was somehow bypassing the `_rsc` query param and therefore our exclusion in CF. Changing from a redirect to a rewrite fixes this and NextJs now no longer does a prefetch of the redirected page.