### PR TITLE
Inject `AWS_ROLE` secret into CI build when configuring AWS credentials

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -145,10 +145,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::518944279943:role/devops_github_actions_wp_frontend
-          role-session-name: testsession
+          role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
# Description

- Injects a new `AWS_ROLE` secret and removes the hardcoded role. Note that this role is temporary since we will dual running publishing to this image and to a new ECR in the tools account. Once we switch over to just using the ECR in the tools account, then we will remove the original infra and role

Fixes #CDD-1846

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
