### PR TITLE
fix: ensure smoke tests run on failure

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -70,7 +70,6 @@ jobs:
 
   slack-notify:
     name: Slack Notify
-    needs: [smoke-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Description

- Smoke tests weren't reporting failures due to `needs` on the notify job