### PR TITLE
Remove build for publishing AMD64 image

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -134,22 +134,6 @@ jobs:
   # Push image to ECR
   ###############################################################################
 
-  publish-image-graviton:
-    name: Publish ARM64 image to ECR
-    needs: [quality-checks, unit-tests, tests-success-gate]
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Build and publish docker image
-        uses: ./.github/actions/publish-image
-        with:
-          role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
-          architecture: arm64
-          image-tag: latest-graviton
-
   publish-image:
     name: Publish image to ECR
     needs: [quality-checks, unit-tests, tests-success-gate]
@@ -163,8 +147,8 @@ jobs:
         uses: ./.github/actions/publish-image
         with:
           role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
-          architecture: amd64
-          image-tag: latest
+          architecture: arm64
+          image-tag: latest-graviton
 
   ###############################################################################
   # Deploy


### PR DESCRIPTION
# Description

This PR includes the following:

- Removes the build which publishes AMD 64 images. So now we only publish ARM 64 images

Fixes #CDD-1817

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
