### PR TITLE
Fix: temporarily disable chart card resizing

### DIFF
--- a/src/app/components/cms/ChartRowCard/ChartRowCard.tsx
+++ b/src/app/components/cms/ChartRowCard/ChartRowCard.tsx
@@ -46,6 +46,7 @@ const setChartCardHeaderSize = (row: HTMLDivElement | null, width: number) => {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const setChartCardTabSize = (row: HTMLDivElement | null, width: number) => {
   // exit early if there's no columns
   if (!row || !row.hasChildNodes()) {


### PR DESCRIPTION
# Description

- Disables our chart card resizing JS for the time being until CDD-1929 can be looked into