### PR TITLE
CDD-1913: Setup <Sheet> component

### DIFF
--- a/src/app/components/ui/ukhsa/Sheet/Sheet.spec.tsx
+++ b/src/app/components/ui/ukhsa/Sheet/Sheet.spec.tsx
@@ -1,0 +1,166 @@
+import userEvent from '@testing-library/user-event'
+import { ComponentProps } from 'react'
+
+import { render, screen } from '@/config/test-utils'
+
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetTitle,
+  SheetTrigger,
+} from './Sheet'
+
+const sheetHeader = (
+  <SheetHeader>
+    <SheetTitle>Sheet title</SheetTitle>
+    <SheetDescription>Sheet description</SheetDescription>
+  </SheetHeader>
+)
+
+const sheetContent = <SheetContent side="left">{sheetHeader}</SheetContent>
+
+const expectedClasses: Record<ComponentProps<typeof SheetContent>['side'], string> = {
+  left: 'inset-y-0 left-0 h-full w-3/4 data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+  right:
+    'inset-y-0 right-0 h-full w-3/4 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+  top: 'inset-x-0 top-0 data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+  bottom: 'inset-x-0 bottom-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+}
+
+describe('Sheet', () => {
+  beforeEach(() => {
+    console.error = jest.fn()
+  })
+
+  test('Opening a sheet from a trigger', async () => {
+    render(
+      <Sheet>
+        <SheetTrigger>Open</SheetTrigger>
+        {sheetContent}
+      </Sheet>
+    )
+
+    const triggerElement = screen.getByRole('button', { name: 'Open' })
+    expect(triggerElement).toHaveAttribute('aria-expanded', 'false')
+    expect(triggerElement).toHaveAttribute('aria-haspopup', 'dialog')
+    expect(triggerElement).toHaveAttribute('aria-controls', 'radix-:r0:')
+
+    expect(screen.queryByRole('sheet', { name: 'Sheet title' })).not.toBeInTheDocument()
+
+    await userEvent.click(triggerElement)
+
+    expect(triggerElement).toHaveAttribute('aria-expanded', 'true')
+
+    const sheet = screen.getByRole('dialog', { name: 'Sheet title' })
+    expect(sheet).toBeInTheDocument()
+    expect(screen.getByText('Sheet description')).toBeInTheDocument()
+  })
+
+  test('Defaulting open on page load', async () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent side="left">{sheetHeader}</SheetContent>
+      </Sheet>
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Sheet title' })).toBeInTheDocument()
+    expect(screen.getByText('Sheet description')).toBeInTheDocument()
+  })
+
+  test('Sheet position - top', async () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent side="top">{sheetHeader}</SheetContent>
+      </Sheet>
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Sheet title' })).toHaveClass(expectedClasses.top)
+  })
+
+  test('Sheet position - bottom', async () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent side="bottom">{sheetHeader}</SheetContent>
+      </Sheet>
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Sheet title' })).toHaveClass(expectedClasses.bottom)
+  })
+
+  test('Sheet position - left', async () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent side="left">{sheetHeader}</SheetContent>
+      </Sheet>
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Sheet title' })).toHaveClass(expectedClasses.left)
+  })
+
+  test('Sheet position - right', async () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent side="right">{sheetHeader}</SheetContent>
+      </Sheet>
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Sheet title' })).toHaveClass(expectedClasses.right)
+  })
+
+  test('Closing a sheet', async () => {
+    render(<Sheet defaultOpen>{sheetContent}</Sheet>)
+
+    expect(screen.getByRole('dialog', { name: 'Sheet title' })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.queryByRole('dialog', { name: 'Sheet title' })).not.toBeInTheDocument()
+  })
+
+  test('Closing a sheet with a custom close button', async () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent side="left">
+          {sheetHeader}
+          <SheetClose>Custom close</SheetClose>
+        </SheetContent>
+      </Sheet>
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Sheet title' })).toBeInTheDocument()
+
+    const customCloseBtn = screen.getByRole('button', { name: 'Custom close' })
+    expect(customCloseBtn).toBeInTheDocument()
+    await userEvent.click(customCloseBtn)
+
+    expect(screen.queryByRole('dialog', { name: 'Sheet title' })).not.toBeInTheDocument()
+  })
+
+  test('Background overlay', () => {
+    const { container } = render(
+      <Sheet defaultOpen>
+        <SheetOverlay>Nothing to see here</SheetOverlay>
+      </Sheet>
+    )
+
+    expect(container.firstChild).toHaveClass(
+      'bg-black/80 fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+    )
+  })
+
+  test('Custom footer', () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent side="left">
+          {sheetHeader}
+          <SheetFooter>Sheet footer</SheetFooter>
+        </SheetContent>
+      </Sheet>
+    )
+
+    expect(screen.getByText('Sheet footer')).toBeInTheDocument()
+  })
+})

--- a/src/app/components/ui/ukhsa/Sheet/Sheet.tsx
+++ b/src/app/components/ui/ukhsa/Sheet/Sheet.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+// eslint-disable-next-line no-restricted-imports
+import * as SheetPrimitive from '@radix-ui/react-dialog'
+import * as React from 'react'
+
+import { clsx } from '@/lib/clsx'
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={clsx(
+      'bg-black/80 fixed inset-0 z-50  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+interface SheetContentProps extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content> {
+  side: 'top' | 'bottom' | 'left' | 'right'
+}
+
+const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
+  ({ side = 'right', className, children, ...props }, ref) => (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={clsx(
+          'fixed z-50 gap-4 bg-white shadow-xl transition ease-in-out data-[state=closed]:duration-200 data-[state=open]:duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out',
+          {
+            'inset-x-0 top-0 data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top': side === 'top',
+            'inset-x-0 bottom-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom':
+              side === 'bottom',
+            'inset-y-0 left-0 h-full w-3/4 data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm':
+              side === 'left',
+            'inset-y-0 right-0 h-full w-3/4 data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm':
+              side === 'right',
+          },
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="govuk-button govuk-button--secondary absolute right-3 top-3 flex w-auto gap-1 disabled:pointer-events-none sm:right-4 sm:top-4">
+          <span>Close</span>
+
+          <svg aria-hidden="true" focusable="false" width="20" height="20" viewBox="0 0 20 20">
+            <path d="M10,8.6L15.6,3L17,4.4L11.4,10L17,15.6L15.6,17L10,11.4L4.4,17L3,15.6L8.6,10L3,4.4L4.4,3L10,8.6Z"></path>
+          </svg>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+)
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={clsx('govuk-!-padding-4 mt-9 flex flex-col text-center sm:text-left', className)} {...props} />
+)
+SheetHeader.displayName = 'SheetHeader'
+
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={clsx('govuk-!-padding-4 flex flex-col-reverse text-center sm:flex-row sm:justify-start', className)}
+    {...props}
+  />
+)
+SheetFooter.displayName = 'SheetFooter'
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title ref={ref} className={clsx('govuk-heading-m govuk-!-margin-bottom-2', className)} {...props} />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description ref={ref} className={clsx('govuk-body mb-0', className)} {...props} />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+}


### PR DESCRIPTION
# Description

Adds a `<Sheet>` component that is very similar to the `<Dialog>` component but is intended for sheet panels in various positions on the page (top, bottom, left or right).

### Usage

```
      <Sheet>
        <SheetTrigger>Open sheet</SheetTrigger>
        <SheetContent side="left">
          <SheetHeader>
            <SheetTitle>East of England</SheetTitle>
            <SheetDescription>Last updated on Thursday, 2 May 2024 at 04:56pm</SheetDescription>
          </SheetHeader>
          <SheetFooter>Footer</SheetFooter>
        </SheetContent>
      </Sheet>
```

### Viewport examples

Mobile
<img width="1296" alt="Screenshot 2024-05-03 at 12 19 19" src="https://github.com/UKHSA-Internal/data-dashboard-frontend/assets/456966/f65090c1-1eb3-4c8f-9e02-2543cb34b677">
 
Tablet
<img width="1292" alt="Screenshot 2024-05-03 at 12 19 35" src="https://github.com/UKHSA-Internal/data-dashboard-frontend/assets/456966/4877b2df-e8e6-4e45-9206-ee13452fd235">

Desktop
<img width="1293" alt="Screenshot 2024-05-03 at 12 18 59" src="https://github.com/UKHSA-Internal/data-dashboard-frontend/assets/456966/5152de41-cd23-41a4-a8ea-79ffe7adfab1">
