### PR TITLE
Removing tag component from no alerts status & test update

### DIFF
--- a/src/app/components/ui/ukhsa/List/ListItemStatus.spec.tsx
+++ b/src/app/components/ui/ukhsa/List/ListItemStatus.spec.tsx
@@ -124,7 +124,7 @@ describe('renders correct tag', () => {
   test('renders no alerts tag', async () => {
     const { getByText } = render(await ListItemStatusTag({ type: 'heat', level: 'no alerts', region: 'London' }))
 
-    expect(getByText('no alerts')).toHaveClass('govuk-tag--grey')
+    expect(getByText('no alerts')).not.toHaveClass('govuk-tag')
     expect(getByText('no alerts')).toHaveAttribute('aria-label', 'There are currently no alerts for London')
   })
 })

--- a/src/app/components/ui/ukhsa/List/ListItemStatus.tsx
+++ b/src/app/components/ui/ukhsa/List/ListItemStatus.tsx
@@ -16,7 +16,7 @@ interface ListItemStatusProps {
 }
 
 export const ListItemStatus = ({ children }: ListItemStatusProps) => {
-  return <div className="relative grid grid-cols-[1fr_100px] gap-2 sm:grid-cols-[50px_1fr_100px]">{children}</div>
+  return <div className="relative grid grid-cols-[1fr_70px] gap-2 sm:grid-cols-[50px_1fr_70px]">{children}</div>
 }
 
 interface ListItemStatusIconProps {
@@ -104,12 +104,11 @@ export const ListItemStatusTag = ({ level, region, type }: ListItemStatusTagProp
 
   return (
     <div
-      className={clsx('govuk-tag govuk-!-margin-right-0 govuk-phase-banner__content__tag m-auto capitalize', {
-        'govuk-tag--green': level === 'green',
-        'govuk-tag--yellow': level === 'yellow',
-        'govuk-tag--orange': level === 'amber',
-        'govuk-tag--red': level === 'red',
-        'govuk-tag--grey': level === 'no alerts',
+      className={clsx('govuk-!-margin-right-0 govuk-phase-banner__content__tag m-auto capitalize', {
+        'govuk-tag govuk-tag--green': level === 'green',
+        'govuk-tag govuk-tag--yellow': level === 'yellow',
+        'govuk-tag govuk-tag--orange': level === 'amber',
+        'govuk-tag govuk-tag--red': level === 'red',
       })}
       aria-label={ariaLabel}
     >


### PR DESCRIPTION
# Description

As recommended, removing govuk-tag component from 'no alerts' status

![image](https://github.com/UKHSA-Internal/data-dashboard-frontend/assets/126494410/d4500897-a4b3-42dd-9fd2-57fa2d0cdbcd)
