### PR TITLE
CDD-1973: Setup summary list component + apply everywhere using the govuk classes

### DIFF
--- a/src/app/(pages)/metrics-documentation/components/MetricsSummary/MetricsSummary.tsx
+++ b/src/app/(pages)/metrics-documentation/components/MetricsSummary/MetricsSummary.tsx
@@ -1,3 +1,10 @@
+import {
+  SummaryList,
+  SummaryListKey,
+  SummaryListRow,
+  SummaryListValue,
+} from '@/app/components/ui/ukhsa/SummaryList/SummaryList'
+
 interface MetricsSummaryProps {
   topic: string
   group: string
@@ -6,21 +13,21 @@ interface MetricsSummaryProps {
 
 export default function MetricsSummary({ topic, group, metric }: MetricsSummaryProps) {
   return (
-    <dl className="govuk-summary-list govuk-!-width-two-thirds">
-      <div className="govuk-summary-list__row">
-        <dt className="govuk-summary-list__key">Topic</dt>
-        <dd className="govuk-summary-list__value">{topic}</dd>
-      </div>
-      <div className="govuk-summary-list__row">
-        <dt className="govuk-summary-list__key">Category</dt>
-        <dd className="govuk-summary-list__value">{group}</dd>
-      </div>
-      <div className="govuk-summary-list__row">
-        <dt className="govuk-summary-list__key">API name</dt>
-        <dd className="govuk-summary-list__value">
+    <SummaryList className="govuk-!-width-two-thirds">
+      <SummaryListRow>
+        <SummaryListKey>Topic</SummaryListKey>
+        <SummaryListValue>{topic}</SummaryListValue>
+      </SummaryListRow>
+      <SummaryListRow>
+        <SummaryListKey>Category</SummaryListKey>
+        <SummaryListValue>{group}</SummaryListValue>
+      </SummaryListRow>
+      <SummaryListRow>
+        <SummaryListKey>API name</SummaryListKey>
+        <SummaryListValue>
           <code>{metric}</code>
-        </dd>
-      </div>
-    </dl>
+        </SummaryListValue>
+      </SummaryListRow>
+    </SummaryList>
   )
 }

--- a/src/app/components/ui/ukhsa/MetricsCard/MetricsCard.tsx
+++ b/src/app/components/ui/ukhsa/MetricsCard/MetricsCard.tsx
@@ -1,6 +1,12 @@
 import Link from 'next/link'
 import { Trans } from 'react-i18next/TransWithoutContext'
 
+import {
+  SummaryList,
+  SummaryListKey,
+  SummaryListRow,
+  SummaryListValue,
+} from '@/app/components/ui/ukhsa/SummaryList/SummaryList'
 import { useTranslation } from '@/app/i18n'
 
 interface MetricsCardProps {
@@ -50,22 +56,22 @@ export async function MetricsCard({ title, href, description, group, topic, metr
       />
 
       <div className="govuk-summary-card__content">
-        <dl className="govuk-summary-list">
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key govuk-body-s">Category</dt>
-            <dd className="govuk-summary-list__value govuk-body-s capitalize">{group}</dd>
-          </div>
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key govuk-body-s">Topic</dt>
-            <dd className="govuk-summary-list__value govuk-body-s">{topic}</dd>
-          </div>
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key govuk-body-s">API name</dt>
-            <dd className="govuk-summary-list__value govuk-body-s">
+        <SummaryList>
+          <SummaryListRow>
+            <SummaryListKey className="govuk-body-s">Category</SummaryListKey>
+            <SummaryListValue className="govuk-body-s capitalize">{group}</SummaryListValue>
+          </SummaryListRow>
+          <SummaryListRow>
+            <SummaryListKey className="govuk-body-s">Topic</SummaryListKey>
+            <SummaryListValue className="govuk-body-s">{topic}</SummaryListValue>
+          </SummaryListRow>
+          <SummaryListRow>
+            <SummaryListKey className="govuk-body-s">API name</SummaryListKey>
+            <SummaryListValue className="govuk-body-s">
               <code>{metric}</code>
-            </dd>
-          </div>
-        </dl>
+            </SummaryListValue>
+          </SummaryListRow>
+        </SummaryList>
       </div>
     </li>
   )

--- a/src/app/components/ui/ukhsa/SummaryList/SummaryList.spec.tsx
+++ b/src/app/components/ui/ukhsa/SummaryList/SummaryList.spec.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { SummaryList, SummaryListKey, SummaryListRow, SummaryListValue } from './SummaryList'
+
+// Mock the clsx function if needed
+jest.mock('@/lib/clsx', () => ({
+  clsx: jest.fn((...classes) => classes.filter(Boolean).join(' ')),
+}))
+
+describe('SummaryList Components', () => {
+  test('SummaryList renders correctly with className', () => {
+    const { container } = render(<SummaryList className="ukhsa-custom-class" />)
+    expect(container.firstChild).toHaveClass('govuk-summary-list ukhsa-custom-class')
+  })
+
+  test('SummaryListRow renders correctly with className', () => {
+    const { container } = render(<SummaryListRow className="ukhsa-custom-class" />)
+    expect(container.firstChild).toHaveClass('govuk-summary-list__row ukhsa-custom-class')
+  })
+
+  test('SummaryListKey renders correctly with className', () => {
+    const { container } = render(<SummaryListKey className="ukhsa-custom-class" />)
+    expect(container.firstChild).toHaveClass('govuk-summary-list__key ukhsa-custom-class')
+  })
+
+  test('SummaryListValue renders correctly with className', () => {
+    const { container } = render(<SummaryListValue className="ukhsa-custom-class" />)
+    expect(container.firstChild).toHaveClass('govuk-summary-list__value ukhsa-custom-class')
+  })
+
+  test('SummaryList components forward refs correctly', () => {
+    const ref = React.createRef<HTMLDListElement>()
+    render(<SummaryList ref={ref} />)
+    expect(ref.current).not.toBeNull()
+
+    const rowRef = React.createRef<HTMLDivElement>()
+    render(<SummaryListRow ref={rowRef} />)
+    expect(rowRef.current).not.toBeNull()
+
+    const keyRef = React.createRef<HTMLElement>()
+    render(<SummaryListKey ref={keyRef} />)
+    expect(keyRef.current).not.toBeNull()
+
+    const valueRef = React.createRef<HTMLElement>()
+    render(<SummaryListValue ref={valueRef} />)
+    expect(valueRef.current).not.toBeNull()
+  })
+
+  test('SummaryList components render children correctly', () => {
+    const { getByText } = render(
+      <SummaryList>
+        <SummaryListRow>
+          <SummaryListKey>Key</SummaryListKey>
+          <SummaryListValue>Value</SummaryListValue>
+        </SummaryListRow>
+      </SummaryList>
+    )
+
+    expect(getByText('Key')).toBeInTheDocument()
+    expect(getByText('Value')).toBeInTheDocument()
+  })
+})

--- a/src/app/components/ui/ukhsa/SummaryList/SummaryList.tsx
+++ b/src/app/components/ui/ukhsa/SummaryList/SummaryList.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import { clsx } from '@/lib/clsx'
+
+const SummaryList = React.forwardRef<React.ElementRef<'dl'>, React.ComponentPropsWithoutRef<'dl'>>(
+  ({ className, ...props }, ref) => <dl ref={ref} className={clsx('govuk-summary-list', className)} {...props} />
+)
+
+const SummaryListRow = React.forwardRef<React.ElementRef<'div'>, React.ComponentPropsWithoutRef<'div'>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={clsx('govuk-summary-list__row', className)} {...props} />
+)
+
+const SummaryListKey = React.forwardRef<React.ElementRef<'dt'>, React.ComponentPropsWithoutRef<'dt'>>(
+  ({ className, ...props }, ref) => <dt ref={ref} className={clsx('govuk-summary-list__key', className)} {...props} />
+)
+
+const SummaryListValue = React.forwardRef<React.ElementRef<'dd'>, React.ComponentPropsWithoutRef<'dd'>>(
+  ({ className, ...props }, ref) => <dd ref={ref} className={clsx('govuk-summary-list__value', className)} {...props} />
+)
+
+export { SummaryList, SummaryListKey, SummaryListRow, SummaryListValue }


### PR DESCRIPTION
# Description

- Adds a low level primitive ui component for composing together GOV.UK summary list components
- Updates all locations using summary list to use the new components

