### PR TITLE
fix: alert view link

### DIFF
--- a/src/app/components/ui/ukhsa/Map/shared/controls/HealthAlertControl.tsx
+++ b/src/app/components/ui/ukhsa/Map/shared/controls/HealthAlertControl.tsx
@@ -85,7 +85,7 @@ const AlertDialogContent = () => {
               dangerouslySetInnerHTML={{ __html: text }}
             />
           </div>
-          <Link href={`/adverse-weather/${category}/${toSlug(regionName)}`} className="govuk-body mb-0">
+          <Link href={`/adverse-weather/${category}-health-alert/${toSlug(regionName)}`} className="govuk-body mb-0">
             {t('map.alertDialog.alertCta')}
           </Link>
           {lastUpdated ? (


### PR DESCRIPTION
# Description

- Fixes the link to the alert page by including the 'heath-alert' portion of the slug. 