### PR TITLE
Fix: Margins around page not found heading

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -15,7 +15,7 @@ export default async function NotFoundPage() {
   return (
     <div className="govuk-grid-row">
       <div className="govuk-grid-column-two-thirds-from-desktop">
-        <h1 className="govuk-heading-xl mb-4">{t('pageNotFound.heading')}</h1>
+        <h1 className="govuk-heading-xl govuk-!-margin-top-2 govuk-!-margin-bottom-4">{t('pageNotFound.heading')}</h1>
         <Trans
           i18nKey="pageNotFound.body"
           t={t}


### PR DESCRIPTION
# Description

Margin issue around page not found heading, before/ after:

![image](https://github.com/UKHSA-Internal/data-dashboard-frontend/assets/126494410/a57bf9c5-04ab-468d-82d6-9355289fc2b3)
![image](https://github.com/UKHSA-Internal/data-dashboard-frontend/assets/126494410/4418347a-e2d7-4ba6-a3b8-674cb9b2cf2b)

