### PR TITLE
fix: Weather Health Alert Smoke tests missing await's

### DIFF
--- a/e2e/tests/weather-health-alerts/weather-health-alerts-map.e2e.ts
+++ b/e2e/tests/weather-health-alerts/weather-health-alerts-map.e2e.ts
@@ -7,8 +7,8 @@ test.describe('Weather health alerts map, smoke test - desktop @smoke', () => {
 
   test('Shows button & opens a map on Weather health alerts page', async ({ app, weatherHealthAlertsMapPage }) => {
     await test.step('opens cold health alerts overlay', async () => {
-      app.goto('/weather-health-alerts/cold')
-      weatherHealthAlertsMapPage.openWeatherHealthAlertsMap()
+      await app.goto('/weather-health-alerts/cold')
+      await weatherHealthAlertsMapPage.openWeatherHealthAlertsMap()
     })
     await test.step('shows exit button', async () => {
       await weatherHealthAlertsMapPage.hasButton('Exit map')
@@ -21,8 +21,8 @@ test.describe('Weather health alerts map, smoke test - tablet @smoke', () => {
 
   test('Shows button & opens a map on Weather health alerts page', async ({ app, weatherHealthAlertsMapPage }) => {
     await test.step('opens cold health alerts overlay', async () => {
-      app.goto('/weather-health-alerts/cold')
-      weatherHealthAlertsMapPage.openWeatherHealthAlertsMap()
+      await app.goto('/weather-health-alerts/cold')
+      await weatherHealthAlertsMapPage.openWeatherHealthAlertsMap()
     })
     await test.step('shows exit button', async () => {
       await weatherHealthAlertsMapPage.hasButton('Exit map')
@@ -35,8 +35,8 @@ test.describe('Weather health alerts map, smoke test - mobile @smoke', () => {
 
   test('Shows button & opens a map on Weather health alerts page', async ({ app, weatherHealthAlertsMapPage }) => {
     await test.step('opens cold health alerts overlay', async () => {
-      app.goto('/weather-health-alerts/cold')
-      weatherHealthAlertsMapPage.openWeatherHealthAlertsMap()
+      await app.goto('/weather-health-alerts/cold')
+      await weatherHealthAlertsMapPage.openWeatherHealthAlertsMap()
     })
     await test.step('shows map buttons', async () => {
       await weatherHealthAlertsMapPage.hasButton('Exit map')
@@ -49,11 +49,11 @@ test.describe('Weather health alerts map, smoke test - no JavaScript @smoke', ()
 
   test('Does not show a map button on Weather health alerts pages', async ({ app, weatherHealthAlertsMapPage }) => {
     await test.step('opens cold health alerts overlay', async () => {
-      app.goto('/weather-health-alerts/cold')
-      app.hasHeading('Cold health alerts')
+      await app.goto('/weather-health-alerts/cold')
+      await app.hasHeading('Cold health alerts')
     })
     await test.step('has no map button showing', async () => {
-      weatherHealthAlertsMapPage.hasNoMapButton()
+      await weatherHealthAlertsMapPage.hasNoMapButton()
     })
   })
 })


### PR DESCRIPTION
# Description

Smoke tests for Weather Health Alerts were missing `await` in several places causing the tests to flake.