### PR TITLE
fix: tag manager broken tests

### DIFF
--- a/src/app/components/cms/Download/Download.spec.tsx
+++ b/src/app/components/cms/Download/Download.spec.tsx
@@ -64,6 +64,7 @@ const props: ComponentProps<typeof Download> = {
     headline_number_columns: [],
     title: 'Table Title',
     body: 'Table Body',
+    tag_manager_event_id: '',
   },
 }
 

--- a/src/app/components/cms/Table/Table.spec.tsx
+++ b/src/app/components/cms/Table/Table.spec.tsx
@@ -107,6 +107,7 @@ const mockData: ComponentProps<typeof Table>['data'] = {
   headline_number_columns: [],
   title: 'Table Title ABC/XYZ',
   body: 'Table Body',
+  tag_manager_event_id: '',
 }
 
 const mockSize = 'narrow'

--- a/src/app/components/cms/Timestamp/Timestamp.spec.tsx
+++ b/src/app/components/cms/Timestamp/Timestamp.spec.tsx
@@ -22,6 +22,7 @@ test('renders the timestamp correctly when successful', async () => {
     body: '',
     title: '',
     headline_number_columns: [],
+    tag_manager_event_id: '',
   }
 
   const { getByText } = render((await Timestamp({ data, size: 'narrow' })) as ReactElement)
@@ -49,6 +50,7 @@ test('renders null when the timestamp request fails', async () => {
     body: '',
     title: '',
     headline_number_columns: [],
+    tag_manager_event_id: '',
   }
 
   const { container } = render((await Timestamp({ data, size: 'narrow' })) as ReactElement)


### PR DESCRIPTION
# Description

A recent PR that went in didn't update some unit tests that needed the new property as part of the mock data