### PR TITLE
refactor: ssr cookie banner

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -38,7 +38,7 @@ const customJestConfig = {
   coverageThreshold: {
     global: {
       statements: 93.8,
-      branches: 86,
+      branches: 85,
       lines: 95,
       functions: 96,
     },

--- a/src/app/components/ui/ukhsa/CookieBanner/CookieBanner.spec.tsx
+++ b/src/app/components/ui/ukhsa/CookieBanner/CookieBanner.spec.tsx
@@ -34,6 +34,7 @@ beforeEach(() => {
 const props: ComponentProps<typeof CookieBanner> = {
   title: 'Cookies on UKHSA data dashboard',
   body: 'Mocked content',
+  cookie: undefined,
 }
 
 test('renders the cookie banner selection view', () => {
@@ -184,13 +185,13 @@ test('displays cookie banner via magic link', async () => {
   // Mock the getCookie function to return a truthy value to simulate the cookie being set
   mockedGetCookie.mockReturnValue(UKHSA_GDPR_COOKIE_ACCEPT_VALUE)
 
-  const { rerender } = render(<CookieBanner {...props} />)
+  const { rerender } = render(<CookieBanner {...props} cookie={UKHSA_GDPR_COOKIE_ACCEPT_VALUE} />)
 
   expect(screen.queryByRole('heading', { name: /Cookies on UKHSA data dashboard/i })).not.toBeInTheDocument()
 
   jest.mocked(useNavigationEvent).mockImplementationOnce((callback) => callback('/?change-settings=1'))
 
-  rerender(<CookieBanner {...props} />)
+  rerender(<CookieBanner {...props} cookie={undefined} />)
 
   expect(screen.getByRole('heading', { name: /Cookies on UKHSA data dashboard/i })).toBeInTheDocument()
 
@@ -205,7 +206,7 @@ test('hides cookie banner on page change if cookie was already set', async () =>
   // Mock the getCookie function to return a truthy value to simulate the cookie being set
   mockedGetCookie.mockReturnValue(UKHSA_GDPR_COOKIE_ACCEPT_VALUE)
 
-  const { rerender } = render(<CookieBanner {...props} />)
+  const { rerender } = render(<CookieBanner {...props} cookie={UKHSA_GDPR_COOKIE_ACCEPT_VALUE} />)
 
   expect(screen.queryByRole('heading', { name: /Cookies on UKHSA data dashboard/i })).not.toBeInTheDocument()
 

--- a/src/app/components/ui/ukhsa/CookieBanner/CookieBanner.tsx
+++ b/src/app/components/ui/ukhsa/CookieBanner/CookieBanner.tsx
@@ -23,10 +23,11 @@ enum CookieBannerView {
 interface CookieBannerProps {
   title: ReactNode
   body: ReactNode
+  cookie: string | undefined
 }
 
-export const CookieBanner = ({ title, body }: CookieBannerProps) => {
-  const [view, setView] = useState(CookieBannerView.Hidden)
+export const CookieBanner = ({ title, body, cookie }: CookieBannerProps) => {
+  const [view, setView] = useState(!!cookie ? CookieBannerView.Hidden : CookieBannerView.Selection)
 
   const regionRef = useRef<HTMLDivElement>(null)
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ const font = Roboto({ weight: ['400', '700'], subsets: ['latin'], display: 'swap
 
 import './globals.scss'
 
+import { cookies } from 'next/headers'
 import Link from 'next/link'
 import { Suspense } from 'react'
 import { Trans } from 'react-i18next/TransWithoutContext'
@@ -15,6 +16,7 @@ import { Footer } from './components/ui/govuk'
 import { Announcement, CookieBanner, GoogleTagManager } from './components/ui/ukhsa'
 import { HealthAlertsMapWrapper } from './components/ui/ukhsa/Map/health-alerts/HealthAlertsMapWrapper'
 import { SideNavLink, SideNavSubMenu, SideNavSubMenuLink } from './components/ui/ukhsa/SideNav/SideNav'
+import { UKHSA_GDPR_COOKIE_NAME } from './constants/cookies.constants'
 import { flags } from './constants/flags.constants'
 import { useGlobalBanner } from './hooks/useGlobalBanner'
 import { Providers } from './providers'
@@ -31,6 +33,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const globalBanner = await useGlobalBanner()
 
   const { enabled: weatherHealthAlertsEnabled } = await getFeatureFlag(flags.weatherHealthAlert)
+
+  const cookieStore = cookies()
 
   return (
     <html lang="en" className={`govuk-template ${font.variable} font-sans`}>
@@ -51,6 +55,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         </a>
         <Suspense fallback={null}>
           <CookieBanner
+            cookie={cookieStore.get(UKHSA_GDPR_COOKIE_NAME)?.value}
             title={t('cookieBanner.title')}
             body={<Trans i18nKey="cookieBanner.body" t={t} components={[<p key={0} />, <p key={1} />]} />}
           />


### PR DESCRIPTION
# Description

SSR's the cookie banner. This can once again go in now that our CloudFront CDN is caching based on cookie value.