### PR TITLE
fix: temp fix for missing env var in client side code

### DIFF
--- a/src/app/utils/app.utils.ts
+++ b/src/app/utils/app.utils.ts
@@ -36,8 +36,7 @@ export const isWellKnownEnvironment = () => {
  * We use the API url to determine the WKE to avoid injecting additional envrionment variables
  */
 export const getSiteUrl = () => {
-  const baseUrl = process.env.BASE_URL
-  if (!baseUrl) throw new Error('Missing environment variable: BASE_URL')
+  const baseUrl = process.env.BASE_URL || 'https://ukhsa-dashboard.data.gov.uk'
   return baseUrl
 }
 


### PR DESCRIPTION
# Description

A recent env var`BASE_URL` was added that wasn't getting picked up in the client side code for WHA. Client side env vars in NextJs need a `next_public_` prefix which we don't have. This is a temporary fix until a better one is put in.