### PR TITLE
Add `telemetries` for AWS RUM client

### DIFF
--- a/src/app/components/ui/ukhsa/AWSRum/AWSRum.spec.tsx
+++ b/src/app/components/ui/ukhsa/AWSRum/AWSRum.spec.tsx
@@ -24,7 +24,7 @@ describe('AWSRum', () => {
       sessionSampleRate: 1,
       identityPoolId: 'test-identity-pool-id',
       endpoint: 'https://dataplane.rum.eu-west-2.amazonaws.com',
-      telemetries: [],
+      telemetries: ['errors', 'performance', 'http'],
       allowCookies: false,
       enableXRay: false,
     })

--- a/src/app/components/ui/ukhsa/AWSRum/AWSRum.tsx
+++ b/src/app/components/ui/ukhsa/AWSRum/AWSRum.tsx
@@ -21,7 +21,7 @@ export function AWSRum({ applicationId, identityPoolId }: AWSRumProps) {
         sessionSampleRate: 1,
         identityPoolId,
         endpoint: 'https://dataplane.rum.eu-west-2.amazonaws.com',
-        telemetries: [],
+        telemetries: ['errors', 'performance', 'http'],
         allowCookies: false,
         enableXRay: false,
       }


### PR DESCRIPTION
# Description

Populates the `telemetries` property on the AWS Rum config object to record errors, http requests and performance stats -> https://github.com/aws-observability/aws-rum-web/blob/main/docs/configuration.md#telemetry-config-array
