### PR TITLE
Include date and metric in downloads request schema x_axis

### DIFF
--- a/src/api/requests/downloads/getDownloads.ts
+++ b/src/api/requests/downloads/getDownloads.ts
@@ -6,7 +6,7 @@ import { logger } from '@/lib/logger'
 
 export const requestSchema = z.object({
   file_format: z.enum(['json', 'csv']),
-  x_axis: z.enum(['age', 'geography', 'sex', 'stratum']).optional().nullable(),
+  x_axis: z.enum(['age', 'geography', 'sex', 'stratum', 'date', 'metric']).optional().nullable(),
   plots: z.array(
     z.object({
       topic: Topics,


### PR DESCRIPTION
# Description

This ticket fixes an bug on the dashboard for time series chart downloads, charts that specify a `date` as their x_axis fail validation because the x_axis enum does not include `date`.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

To reproduce this issue create a chart or find an existing chart in the CMS that uses time series data and provides the `date` as its x_axis choice. Once this has been added to the dashboard move to the `download` tab and download both `csv` and json formats of the file. The contents of this file are not the downloaded data but an error response.

Once the fix has been deployed to your test environment you can download the file and the contents are correct.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
