### PR TITLE
Pass alertType into handleClick callback

### DIFF
--- a/src/app/components/ui/ukhsa/MiniMap/MiniMap.tsx
+++ b/src/app/components/ui/ukhsa/MiniMap/MiniMap.tsx
@@ -105,7 +105,7 @@ export function MiniMap({ alertType }: MiniMapProps): React.ReactElement | null 
     (regionId: string) => {
       const url = new URL('/', window.location.origin)
       url.searchParams.set('v', 'map')
-      url.searchParams.set('type', 'heat')
+      url.searchParams.set('type', alertType)
       url.searchParams.set('fid', regionId)
       router.push(url.toString(), { scroll: false })
     },


### PR DESCRIPTION
# Description

Passes the alertType prop into the `handleClick` callback so that when users click into a region it takes them to the corresponding map. Not just the heat map

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
