### PR TITLE
fix: temporarily disable unlighthouse on prs

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -50,6 +50,7 @@ jobs:
     name: Lighthouse
     needs: [build]
     runs-on: ubuntu-latest
+    if: false # Temporarily disabled due to config overriding CLI params and running against production
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node


### PR DESCRIPTION
# Description

The `site` option that was added to the unlighthouse config is overriding the CLI options passed in from the CI job, meaning we are running this against prod, instead of the built environment within this pipeline. Temporarily disabling the job until we can resolve the underlying issue