### PR TITLE
CDD-2502: Updated lighthouse config to ignore the topics pages 

### DIFF
--- a/unlighthouse.config.ts
+++ b/unlighthouse.config.ts
@@ -1,6 +1,6 @@
 export default {
   scanner: {
-    exclude: ['/healthcare-associated-infections-hcai/healthcare-associated-infections/'],
+    exclude: ['/healthcare-associated-infections-hcai/healthcare-associated-infections/', '/respiratory-viruses/*'],
   },
   puppeteerOptions: {
     args: ['--no-sandbox', '--disable-setuid-sandbox'],


### PR DESCRIPTION
This PR adds the topic pages to the unlighhouse ignore file as we know the amount of information rendered on the topics pages can cause false positives in lighthouse performance scans

Fixes #CDD-2502

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [x] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
