### PR TITLE
CDD-2505: Updated the dev dashboard to allow the selection of multiple banners

### DIFF
--- a/src/app/(pages)/switchboard/(pages)/global-banners/page.tsx
+++ b/src/app/(pages)/switchboard/(pages)/global-banners/page.tsx
@@ -5,6 +5,7 @@ import { BackLink } from '@/app/components/ui/ukhsa/View/BackLink/Backlink'
 import { Heading } from '@/app/components/ui/ukhsa/View/Heading/Heading'
 import { UKHSA_SWITCHBOARD_COOKIE_NAME } from '@/app/constants/app.constants'
 
+import GlobalBannerRadio from '../../components/GlobalBannerRadio'
 import { StatusSelect } from '../../components/StatusSelect'
 import { heading } from '../../shared/constants'
 import { getSwitchBoardState, syncState } from '../../shared/state'
@@ -42,47 +43,10 @@ export default function SwitchBoard() {
             <label className="govuk-label" htmlFor="global-banners.scenario.Information">
               Variant
             </label>
-            <div className="govuk-radios__item">
-              <input
-                defaultChecked={globalBanner.scenario === 'Information'}
-                className="govuk-radios__input"
-                id="global-banners.scenario.Information"
-                name="global-banners.scenario"
-                type="radio"
-                value="Information"
-              />
-              <label className="govuk-label govuk-radios__label" htmlFor="global-banners.scenario.Information">
-                Information
-              </label>
-            </div>
-
-            <div className="govuk-radios__item">
-              <input
-                defaultChecked={globalBanner.scenario === 'Warning'}
-                className="govuk-radios__input"
-                id="global-banners.scenario.Warning"
-                name="global-banners.scenario"
-                type="radio"
-                value="Warning"
-              />
-              <label className="govuk-label govuk-radios__label" htmlFor="global-banners.scenario.Warning">
-                Warning
-              </label>
-            </div>
-
-            <div className="govuk-radios__item">
-              <input
-                defaultChecked={!globalBanner.scenario}
-                className="govuk-radios__input"
-                id="global-banners.scenario.Inactive"
-                name="global-banners.scenario"
-                type="radio"
-                value=""
-              />
-              <label className="govuk-label govuk-radios__label" htmlFor="global-banners.scenario.Inactive">
-                Inactive
-              </label>
-            </div>
+            <GlobalBannerRadio globalBannerScenario={globalBanner.scenario} radioOption="Information" />
+            <GlobalBannerRadio globalBannerScenario={globalBanner.scenario} radioOption="Warning" />
+            <GlobalBannerRadio globalBannerScenario={globalBanner.scenario} radioOption="Multiple" />
+            <GlobalBannerRadio globalBannerScenario={globalBanner.scenario} radioOption="Inactive" />
           </div>
         </fieldset>
         <button type="submit" className="govuk-button">

--- a/src/app/(pages)/switchboard/components/GlobalBannerRadio.tsx
+++ b/src/app/(pages)/switchboard/components/GlobalBannerRadio.tsx
@@ -1,0 +1,24 @@
+interface GlobalBannerRadioProps {
+  globalBannerScenario: string
+  radioOption: string
+}
+
+const GlobalBannerRadio = ({ globalBannerScenario, radioOption }: GlobalBannerRadioProps) => {
+  return (
+    <div className="govuk-radios__item">
+      <input
+        defaultChecked={globalBannerScenario === radioOption}
+        className="govuk-radios__input"
+        id={`global-banners.scenario.${radioOption}`}
+        name="global-banners.scenario"
+        type="radio"
+        value={radioOption == 'Inactive' ? '' : radioOption}
+      />
+      <label className="govuk-label govuk-radios__label" htmlFor={`global-banners.scenario.${radioOption}`}>
+        {radioOption}
+      </label>
+    </div>
+  )
+}
+
+export default GlobalBannerRadio

--- a/src/app/(pages)/switchboard/shared/schema.ts
+++ b/src/app/(pages)/switchboard/shared/schema.ts
@@ -32,7 +32,7 @@ export const switchBoardSchema = z.object({
         }),
       }),
     }),
-    'global-banners': baseProps(bannerTypes.or(z.literal(''))),
+    'global-banners': baseProps(bannerTypes.or(z.literal('Multiple')).or(z.literal(''))),
     menus: baseProps(z.enum(['Inactive', 'MegaMenu'])),
   }),
   flags: z.object({

--- a/src/mock-server/handlers/global-banners/fixtures/global-banner-information.ts
+++ b/src/mock-server/handlers/global-banners/fixtures/global-banner-information.ts
@@ -3,16 +3,6 @@ import { ResponseSchema } from '@/api/requests/global-banners/getGlobalBanners'
 export const globalBannerInformation: ResponseSchema = {
   active_global_banners: [
     {
-      title: 'This is an warning level site wide banner. Puppies are cute',
-      body: '<p data-block-key="97ug6">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis.</p>',
-      banner_type: 'Warning',
-    },
-    {
-      title: 'This is another warning level site wide banner. Puppies are cute',
-      body: '<p data-block-key="97ug6">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis.</p>',
-      banner_type: 'Warning',
-    },
-    {
       title: 'This is an information level site wide banner. Puppies are cute',
       body: '<p data-block-key="97ug6">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis.</p>',
       banner_type: 'Information',

--- a/src/mock-server/handlers/global-banners/fixtures/global-banner-multiple.ts
+++ b/src/mock-server/handlers/global-banners/fixtures/global-banner-multiple.ts
@@ -1,0 +1,21 @@
+import { ResponseSchema } from '@/api/requests/global-banners/getGlobalBanners'
+
+export const globalBannerMultiple: ResponseSchema = {
+  active_global_banners: [
+    {
+      title: 'This is an warning level site wide banner. Puppies are cute',
+      body: '<p data-block-key="97ug6">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis.</p>',
+      banner_type: 'Warning',
+    },
+    {
+      title: 'This is another warning level site wide banner. Puppies are cute',
+      body: '<p data-block-key="97ug6">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis.</p>',
+      banner_type: 'Warning',
+    },
+    {
+      title: 'This is an information level site wide banner. Puppies are cute',
+      body: '<p data-block-key="97ug6">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis.</p>',
+      banner_type: 'Information',
+    },
+  ],
+}

--- a/src/mock-server/handlers/global-banners/v2.ts
+++ b/src/mock-server/handlers/global-banners/v2.ts
@@ -5,6 +5,7 @@ import { logger } from '@/lib/logger'
 
 import { globalBannerInactive } from './fixtures/global-banner-inactive'
 import { globalBannerInformation } from './fixtures/global-banner-information'
+import { globalBannerMultiple } from './fixtures/global-banner-multiple'
 import { globalBannerWarning } from './fixtures/global-banner-warning'
 
 export default async function handler(req: Request, res: Response) {
@@ -26,6 +27,10 @@ export default async function handler(req: Request, res: Response) {
 
     if (scenario === 'Warning') {
       return res.status(status).send(globalBannerWarning)
+    }
+
+    if (scenario === 'Multiple') {
+      return res.status(status).send(globalBannerMultiple)
     }
 
     return res.status(status).send(globalBannerInactive)


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #CDD-2505

- This Pr adds the ability to change the global banner settings for local development using the dashboard. You can configure the type of Global banners that are displayed to either show, Information, Warning or Multiple Global Banners

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
