### PR TITLE
Send stratum field in headline / trend request to backend

### DIFF
--- a/src/api/requests/headlines/getHeadlines.ts
+++ b/src/api/requests/headlines/getHeadlines.ts
@@ -11,7 +11,7 @@ export const requestSchema = z.object({
   geography: z.optional(Geography),
   age: z.optional(Age),
   sex: z.optional(Sex),
-  statum: z.optional(Stratum),
+  stratum: z.optional(Stratum),
 })
 
 export const responseSchema = z.object({

--- a/src/api/requests/trends/getTrends.ts
+++ b/src/api/requests/trends/getTrends.ts
@@ -12,7 +12,7 @@ export const requestSchema = z.object({
   geography: z.optional(Geography),
   age: z.optional(Age),
   sex: z.optional(Sex),
-  statum: z.optional(Stratum),
+  stratum: z.optional(Stratum),
 })
 
 export const responseSchema = z.object({


### PR DESCRIPTION
# Description

- Fixes the typo in the zod schema which would have meant we were previously consuming the `statum` field instead of `stratum` from the CMS response and sending that to the backend

Fixes #CDD-2531

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
