### PR TITLE
Task/implement v2 caching switch/cdd 2572

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const dns = require('dns')
 
 dns.setDefaultResultOrder('ipv4first')
 
-const sharedCache = process.env.NODE_ENV === 'production'
+const sharedCache = process.env.CACHING_V2_ENABLED === 'true'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/src/app/(topics)/(weather-health-alerts)/weather-health-alerts/[weather]/[region]/page.tsx
+++ b/src/app/(topics)/(weather-health-alerts)/weather-health-alerts/[weather]/[region]/page.tsx
@@ -4,11 +4,11 @@ import { HealthAlertTypes } from '@/api/models/Alerts'
 import { PageType } from '@/api/requests/cms/getPages'
 import { getPageBySlug } from '@/api/requests/getPageBySlug'
 import { RelatedLinksWrapper } from '@/app/components/ui/ukhsa/RelatedLinks/RelatedLinksWrapper'
-import { authEnabled } from '@/config/constants'
+import { cachingEnabled } from '@/config/constants'
 
 import AlertBody from './AlertBody'
 
-export const dynamic = authEnabled ? 'auto' : 'force-dynamic'
+export const dynamic = cachingEnabled ? 'auto' : 'force-dynamic'
 
 export async function generateMetadata({ params: { region } }: { params: { region: string } }): Promise<Metadata> {
   return {

--- a/src/app/(topics)/(weather-health-alerts)/weather-health-alerts/[weather]/page.tsx
+++ b/src/app/(topics)/(weather-health-alerts)/weather-health-alerts/[weather]/page.tsx
@@ -13,11 +13,11 @@ import { RelatedLinksWrapper } from '@/app/components/ui/ukhsa/RelatedLinks/Rela
 import { Breadcrumbs } from '@/app/components/ui/ukhsa/View/Breadcrumbs/Breadcrumbs'
 import { Heading } from '@/app/components/ui/ukhsa/View/Heading/Heading'
 import { renderCompositeBlock } from '@/app/utils/cms.utils'
-import { authEnabled } from '@/config/constants'
+import { cachingEnabled } from '@/config/constants'
 
 import AlertList from './AlertList'
 
-export const dynamic = authEnabled ? 'auto' : 'force-dynamic'
+export const dynamic = cachingEnabled ? 'auto' : 'force-dynamic'
 
 export async function generateMetadata({ params: { weather } }: { params: { weather: string } }): Promise<Metadata> {
   const {

--- a/src/app/(topics)/(weather-health-alerts)/weather-health-alerts/page.tsx
+++ b/src/app/(topics)/(weather-health-alerts)/weather-health-alerts/page.tsx
@@ -11,9 +11,9 @@ import { RelatedLinksWrapper } from '@/app/components/ui/ukhsa/RelatedLinks/Rela
 import { Breadcrumbs } from '@/app/components/ui/ukhsa/View/Breadcrumbs/Breadcrumbs'
 import { Heading } from '@/app/components/ui/ukhsa/View/Heading/Heading'
 import { renderCompositeBlock } from '@/app/utils/cms.utils'
-import { authEnabled } from '@/config/constants'
+import { cachingEnabled } from '@/config/constants'
 
-export const dynamic = authEnabled ? 'auto' : 'force-dynamic'
+export const dynamic = cachingEnabled ? 'auto' : 'force-dynamic'
 
 export async function generateMetadata() {
   const {

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,7 +1,5 @@
-import { revalidateTag } from 'next/cache'
+import { revalidatePath } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
-
-import { cacheFetchTags } from '@/config/constants'
 
 export async function POST(req: NextRequest) {
   try {
@@ -13,7 +11,7 @@ export async function POST(req: NextRequest) {
       return new Response(JSON.stringify({ message: 'Invalid secret' }), { status: 401 })
     }
 
-    revalidateTag(cacheFetchTags.public)
+    revalidatePath('/', 'layout')
 
     return NextResponse.json({ revalidated: true, now: Date.now() })
   } catch (err) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,7 +10,7 @@ import { Trans } from 'react-i18next/TransWithoutContext'
 
 import { AWSRum } from '@/app/components/ui/ukhsa/Scripts/AWSRum/AWSRum'
 import { getServerTranslation } from '@/app/i18n'
-import { authEnabled } from '@/config/constants'
+import { cachingEnabled } from '@/config/constants'
 
 import { Footer } from './components/ui/govuk'
 import { CookieBanner } from './components/ui/ukhsa'
@@ -20,7 +20,7 @@ import { GovUK } from './components/ui/ukhsa/Scripts/GovUK/GovUK'
 import { UKHSA_GDPR_COOKIE_NAME } from './constants/cookies.constants'
 import { Providers } from './providers'
 
-export const dynamic = authEnabled ? 'auto' : 'force-dynamic'
+export const dynamic = cachingEnabled ? 'auto' : 'force-dynamic'
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const { t } = await getServerTranslation('common')

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,12 +3,12 @@ import { MetadataRoute } from 'next'
 
 import { getPages, PageType } from '@/api/requests/cms/getPages'
 import { getHealthAlerts } from '@/api/requests/health-alerts/getHealthAlerts'
-import { authEnabled } from '@/config/constants'
+import { cachingEnabled } from '@/config/constants'
 import { logger } from '@/lib/logger'
 
 import { getSiteUrl, toSlug } from './utils/app.utils'
 
-export const dynamic = authEnabled ? 'auto' : 'force-dynamic'
+export const dynamic = cachingEnabled ? 'auto' : 'force-dynamic'
 
 export const changeFrequencyMap: Record<number, MetadataRoute.Sitemap[number]['changeFrequency']> = {
   1: 'always',

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,10 +4,28 @@
 export const authEnabled = process.env.AUTH_ENABLED === 'true'
 
 /**
- * The default cache revalidation interval (10 minutes)
+ * Checks to see if ISR caching is enabled
+ * Note that this is currently under development and should **not** be used in production
+ */
+export const ISRCachingEnabled = process.env.CACHING_V2_ENABLED === 'true'
+
+/**
+ * Checks to see if Next.js caching is enabled
+ */
+export const cachingEnabled = authEnabled || ISRCachingEnabled
+
+/**
+ * The default cache revalidation interval (30 days)
+ *  for the public app when ISR caching is enabled
  * Can be overridden per request
  */
-export const cacheRevalidationInterval = 600
+export const publicCacheRevalidationInterval = 2592000
+
+/**
+ * The default cache revalidation interval (10 minutes) for the authenticated app
+ * Can be overridden per request
+ */
+export const nonPublicCacheRevalidationInterval = 600
 
 /**
  * Associated fetch tags for the Next.js data cache
@@ -70,4 +88,3 @@ export const defaultAuthProvider = 'cognito'
  * Redirect path after successful sign out
  */
 export const authSignOutRedirectionPath = '/start?logout=success'
-


### PR DESCRIPTION
# Description

- Checks the `CACHING_V2_ENABLED` env var and if true, applies the existing cache handler so that the containers use the shared redis cache
- Sets the default revalidate time to 30 days when CACHING_V2_ENABLED is true

Fixes #CDD-2572

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
