### PR TITLE
Allow unauthenticated access to robots.txt route

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,13 +25,9 @@ export const middleware: NextMiddleware = async (request: NextRequest) => {
 
   // Handle auth first if enabled
   if (process.env.AUTH_ENABLED === 'true') {
-    // Filter out next-auth API requests
-    if (request.nextUrl.pathname.startsWith('/api/auth/')) {
-      return response
-    }
+    const unauthenticatedPaths = ['/api/auth/', '/api/health', '/robots.txt']
 
-    // Ensure the health check endpoint is always reachable
-    if (request.nextUrl.pathname.startsWith('/api/health')) {
+    if (unauthenticatedPaths.some((path) => request.nextUrl.pathname.startsWith(path))) {
       return response
     }
 


### PR DESCRIPTION
# Description

In the auth middleware, we now bypass the `/robots.txt` path allowing unathenticated access to it instead of routing unathenicated sessions to the start page when they are trying to reach the `robots.txt` route.

Fixes #CDD-2459

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
