### PR TITLE
Bugfix: CDD-2588 - Timeseries filter appearing without CMS

### DIFF
--- a/src/app/components/cms/pages/Topic.tsx
+++ b/src/app/components/cms/pages/Topic.tsx
@@ -41,6 +41,9 @@ export default async function TopicPage({
       value.content.map((content) => {
         if (content.type === 'chart_row_card' && content.value.columns) {
           content.value.columns.map((column) => {
+            if (!column.value.show_timeseries_filter) return
+
+            // Check timeseries enabled
             const chartId = toSlug(column.value.chart[0].value.metric)
 
             const existingFilter = timeseriesFilter.split(';').find((filter) => filter.startsWith(chartId))

--- a/src/app/components/cms/pages/Topic.tsx
+++ b/src/app/components/cms/pages/Topic.tsx
@@ -41,9 +41,9 @@ export default async function TopicPage({
       value.content.map((content) => {
         if (content.type === 'chart_row_card' && content.value.columns) {
           content.value.columns.map((column) => {
+            // Check timeseries enabled per chart
             if (!column.value.show_timeseries_filter) return
 
-            // Check timeseries enabled
             const chartId = toSlug(column.value.chart[0].value.metric)
 
             const existingFilter = timeseriesFilter.split(';').find((filter) => filter.startsWith(chartId))


### PR DESCRIPTION
# Description

Before filtering data to one year, check chart-by-chart that filter is added in CMS

Fixes #CDD-2588

