### PR TITLE
Rename geography_name -> geography in alerts zod schema

### DIFF
--- a/src/api/models/Alerts.ts
+++ b/src/api/models/Alerts.ts
@@ -13,7 +13,7 @@ export const HealthAlert = z.object({
   period_start: z.string().nullable(),
   period_end: z.string().nullable(),
   refresh_date: z.string().nullable(),
-  geography_name: z.string(),
+  geography: z.string(),
   geography_code: z.string(),
 })
 

--- a/src/app/hooks/queries/useWeatherHealthAlert.ts
+++ b/src/app/hooks/queries/useWeatherHealthAlert.ts
@@ -15,7 +15,7 @@ export default function useWeatherHealthAlert({ type, regionId }: WeatherHealthA
     select(data) {
       if (data.success) {
         const {
-          geography_name: regionName,
+          geography: regionName,
           status,
           text,
           risk_score: riskScore,

--- a/src/mock-server/handlers/alerts/v1/fixtures/detail.ts
+++ b/src/mock-server/handlers/alerts/v1/fixtures/detail.ts
@@ -9,6 +9,6 @@ export const alertRegionFixture: HealthAlert = {
   period_start: '2024-05-06 12:00:00',
   period_end: '2024-05-08 12:00:00',
   refresh_date: '2024-05-07 12:00:00',
-  geography_name: '',
+  geography: '',
   geography_code: '',
 }


### PR DESCRIPTION
# Description

Fixes the mismatch between the backend and the frontend `geography_name` / `geography` field name in the zod schema for the inbound alert

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
