### PR TITLE
Temporarily hardcode `%` as suffix to main metric value in tooltip

### DIFF
--- a/src/app/components/ui/ukhsa/Map/shared/layers/CoverLayer.tsx
+++ b/src/app/components/ui/ukhsa/Map/shared/layers/CoverLayer.tsx
@@ -267,6 +267,7 @@ const CoverLayer = <T extends LayerWithFeature>({
             } else {
               // Clicked new feature - create and open tooltip
               const featureData = getFeatureData(layer.feature.properties[geoJsonFeatureId])
+              const mainMetricValue = featureData?.metric_value ? `${featureData.metric_value}%` : 'No Data Available'
 
               const { regionName, nationName, vaccination } = renderTooltip(featureData)
               activeTooltipLayerRef.current = layer
@@ -277,7 +278,7 @@ const CoverLayer = <T extends LayerWithFeature>({
                   <b>Local Authority</b>: ${feature.properties['CTYUA24NM']}<br />
                   <hr style="margin: 8px 0; border: none; border-top: 1px solid #ccc;" />
                   <b>Vaccination</b>: ${vaccination}</> </br>
-                  <b>Level of Coverage</b>: ${featureData?.metric_value ? featureData.metric_value : 'No Data Available'}</>
+                  <b>Level of Coverage</b>: ${mainMetricValue}</>
                   ${
                     featureData?.accompanying_points
                       ? featureData?.accompanying_points


### PR DESCRIPTION
# Description

- Temporarily hardcodes a `%` to be suffixed to the main metric value in the maps tooltip

Fixes #CDD-2685

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
