### PR TITLE
Feature/cdd 2787 map update

### DIFF
--- a/src/app/components/ui/ukhsa/Map/shared/controls/AttributionControl.spec.tsx
+++ b/src/app/components/ui/ukhsa/Map/shared/controls/AttributionControl.spec.tsx
@@ -186,7 +186,7 @@ describe('AttributionControl', () => {
     render(<AttributionControl position="bottomright" />)
 
     const scrollArea = screen.getByTestId('scroll-area')
-    expect(scrollArea).toHaveClass('h-[10rem]')
+    expect(scrollArea).toHaveClass('h-[12rem]')
   })
 
   test('works with different control positions', () => {

--- a/src/app/components/ui/ukhsa/Map/shared/controls/AttributionControl.tsx
+++ b/src/app/components/ui/ukhsa/Map/shared/controls/AttributionControl.tsx
@@ -64,8 +64,10 @@ export function AttributionControl({ position }: AttributionControlProps) {
           <DialogHeader aria-hidden className="govuk-visually-hidden">
             <DialogTitle>&copy; Copyright</DialogTitle>
           </DialogHeader>
-          <ScrollArea className="h-[10rem]">
+          <ScrollArea className="h-[12rem]">
             <p>{text}</p>
+            <p>Source: Office for National Statistics licensed under the Open Government Licence v.3.0.</p>
+            <p>Contains OS data &copy; Crown copyright and database right 2025.</p>
             <ScrollBar />
           </ScrollArea>
         </DialogContent>

--- a/src/app/components/ui/ukhsa/Map/shared/layers/BaseLayer.tsx
+++ b/src/app/components/ui/ukhsa/Map/shared/layers/BaseLayer.tsx
@@ -11,7 +11,7 @@ interface BaseLayerProps extends Partial<TileLayerProps> {}
 
 const BaseLayer = ({
   url = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-  attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors.',
   ...rest
 }: BaseLayerProps) => {
   return <TileLayer {...rest} attribution={attribution} url={url} />

--- a/src/app/components/ui/ukhsa/Map/shared/layers/CoverLayer.tsx
+++ b/src/app/components/ui/ukhsa/Map/shared/layers/CoverLayer.tsx
@@ -417,7 +417,7 @@ const CoverLayer = <T extends LayerWithFeature>({
         style.fillColor = 'rgba(62, 62, 62, 0.5)'
       }
       style.fillOpacity = 1
-      style.color = 'rgb(255, 255, 255)'
+      style.color = 'rgb(0, 0, 0)'
       style.weight = 1
     } else if (featureCollection.name === 'Regions') {
       style.fillColor = 'rgba(99, 232, 89, 0)'


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #CDD-2787

This update changes the map so that the borders of the UTLAs are set to black
It also updates the copyright statement for the attribution control. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
