### PR TITLE
Override geography codes as `E10000023` for North Yorkshire and `E10000027` for Somerset

### DIFF
--- a/src/app/components/ui/ukhsa/Map/shared/data/geojson/local-authorities.ts
+++ b/src/app/components/ui/ukhsa/Map/shared/data/geojson/local-authorities.ts
@@ -13697,7 +13697,10 @@ const localAuthoritiesFeatureCollection: FeatureCollection = {
       },
       properties: {
         FID: 62,
-        CTYUA24CD: 'E06000065',
+        // This has been manually altered so that
+        // the map references the matching North Yorkshire record
+        // in the database
+        CTYUA24CD: 'E10000023',
         CTYUA24NM: 'North Yorkshire',
         CTYUA24NMW: ' ',
         BNG_E: 429508,
@@ -14110,7 +14113,10 @@ const localAuthoritiesFeatureCollection: FeatureCollection = {
       },
       properties: {
         FID: 63,
-        CTYUA24CD: 'E06000066',
+        // This has been manually altered so that
+        // the map references the matching Somerset record
+        // in the database
+        CTYUA24CD: 'E10000027',
         CTYUA24NM: 'Somerset',
         CTYUA24NMW: ' ',
         BNG_E: 309294,


### PR DESCRIPTION
# Description

Overrides the referenced geography codes for North Yorkshire and Somerset to be `E10000023` and `E10000027` respectively


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
