### PR TITLE
Feature/cdd 2827 subplot tabular data mocks

### DIFF
--- a/src/api/models/Topics.ts
+++ b/src/api/models/Topics.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const Topics = z
-  .enum(['COVID-19', 'Influenza', 'Adenovirus', 'RSV', 'Rhinovirus', 'Parainfluenza', 'hMPV'])
+  .enum(['COVID-19', 'Influenza', 'Adenovirus', 'RSV', 'Rhinovirus', 'Parainfluenza', 'hMPV', 'immunisation'])
   .or(z.string())
 
 export type Topics = z.infer<typeof Topics>

--- a/src/api/requests/tables/subplot/getSubplotTables.spec.ts
+++ b/src/api/requests/tables/subplot/getSubplotTables.spec.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+
+import { client } from '@/api/utils/api.utils'
+import { logger } from '@/lib/logger'
+import { defaultCoverageTableValues } from '@/mock-server/handlers/tables/subplot/fixtures'
+
+import { getSubplotTables, responseSchema } from './getSubplotTables'
+
+type Response = z.infer<typeof responseSchema>
+type successResponse = z.SafeParseSuccess<Response>
+type ErrorResponse = z.SafeParseError<Response>
+
+const validPayload = {
+  chart_parameters: {
+    theme: 'mock theme',
+    sub_theme: 'mock sub theme',
+    topic: 'mock topic',
+    metric_value_ranges: [],
+  },
+  subplots: [
+    {
+      subplot_title: 'mocked subplot title',
+      subplot_parameters: {},
+      plots: [],
+    },
+  ],
+}
+
+describe('getSubplotTables', () => {
+  test('Returns tabular data for a subplot chart for immunisation topic', async () => {
+    const requestBody = validPayload
+
+    jest.mocked(client).mockResolvedValueOnce({ data: defaultCoverageTableValues, status: 200 })
+
+    const result = await getSubplotTables(requestBody)
+
+    expect(result).toEqual<successResponse>({ success: true, data: defaultCoverageTableValues })
+  })
+
+  test('Handles invalid json received from the API', async () => {
+    const requestBody = validPayload
+    const invalidResponse = {
+      ...defaultCoverageTableValues,
+      subplots: { invalid_key: 'invalid_value' },
+    }
+    jest.mocked(client).mockResolvedValueOnce({
+      data: invalidResponse,
+      status: 200,
+    })
+
+    const result = await getSubplotTables(requestBody)
+
+    expect(result).toEqual<ErrorResponse>({
+      success: false,
+      error: new z.ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          received: 'object',
+          path: [],
+          message: 'Expected array, received object',
+        },
+      ]),
+    })
+  })
+
+  test('Handles generic http error', async () => {
+    const requestBody = validPayload
+    jest.mocked(client).mockRejectedValueOnce({
+      status: 400,
+    })
+
+    const result = await getSubplotTables(requestBody)
+
+    expect(logger.error).toHaveBeenCalledTimes(1)
+
+    expect(result).toEqual<ErrorResponse>({
+      success: false,
+      error: new z.ZodError([
+        {
+          code: 'invalid_type',
+          expected: 'array',
+          received: 'object',
+          path: [],
+          message: 'Expected array, received object',
+        },
+      ]),
+    })
+  })
+})

--- a/src/api/requests/tables/subplot/getSubplotTables.tsx
+++ b/src/api/requests/tables/subplot/getSubplotTables.tsx
@@ -1,0 +1,86 @@
+import { z } from 'zod'
+
+import { client } from '@/api/utils/api.utils'
+import { isSSR } from '@/app/utils/app.utils'
+import { logger } from '@/lib/logger'
+
+export const requestSchema = z.object({
+  chart_parameters: z.object({
+    x_axis: z.string().nullable().optional(),
+    y_axis: z.string().nullable().optional(),
+    theme: z.string(),
+    sub_theme: z.string(),
+    date_from: z.string().nullable().optional(),
+    date_to: z.string().nullable().optional(),
+    age: z.string().nullable().optional(),
+    sex: z.string().nullable().optional(),
+    topic: z.string().nullable().optional(),
+    metric: z.string().nullable().optional(),
+    stratum: z.string().nullable().optional(),
+    metric_value_ranges: z.array(
+      z
+        .object({
+          start: z.string(),
+          end: z.string(),
+        })
+        .nullable()
+        .optional()
+    ),
+  }),
+  subplots: z.array(
+    z.object({
+      subplot_title: z.string(),
+      subplot_parameters: z.object({
+        age: z.string().nullable().optional(),
+        sex: z.string().nullable().optional(),
+        topic: z.string().nullable().optional(),
+        metric: z.string().nullable().optional(),
+        stratum: z.string().nullable().optional(),
+        theme: z.string().nullable().optional(),
+        sub_theme: z.string().nullable().optional(),
+      }),
+      plots: z.array(
+        z.object({
+          label: z.string().nullable().optional(),
+          geography: z.string().nullable().optional(),
+          geography_type: z.string().nullable().optional(),
+          line_colour: z.string().nullable().optional(),
+          age: z.string().nullable().optional(),
+          sex: z.string().nullable().optional(),
+          topic: z.string().nullable().optional(),
+          metric: z.string().nullable().optional(),
+          stratum: z.string().nullable().optional(),
+          theme: z.string().nullable().optional(),
+          sub_theme: z.string().nullable().optional(),
+        })
+      ),
+    })
+  ),
+})
+
+export const responseSchema = z.array(
+  z.object({
+    reference: z.string(),
+    values: z.array(
+      z.object({
+        label: z.string(),
+        value: z.string().nullable().optional(),
+        in_reporting_delay_period: z.boolean(),
+      })
+    ),
+  })
+)
+
+export type RequestParams = z.infer<typeof requestSchema>
+export type Response = z.infer<typeof responseSchema>
+
+export const getSubplotTables = async (body: RequestParams) => {
+  try {
+    const path = isSSR ? `tables/subplot/v1` : `proxy/tables/subplot/v1`
+    const { data } = await client<Response>(path, { body })
+    return responseSchema.safeParse(data)
+  } catch (error) {
+    logger.error(error)
+    return responseSchema.safeParse(error)
+  }
+}

--- a/src/app/api/proxy/tables/subplot/v1/route.ts
+++ b/src/app/api/proxy/tables/subplot/v1/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getSubplotTables, RequestParams } from '@/api/requests/tables/subplot/getSubplotTables'
+
+export async function POST(req: NextRequest) {
+  const body: RequestParams = await req.json()
+
+  if (!body) {
+    return new NextResponse('Missing category', {
+      status: 500,
+    })
+  }
+
+  const proxiedResponse = await getSubplotTables(body)
+
+  if (proxiedResponse.data) {
+    return NextResponse.json(proxiedResponse.data)
+  }
+
+  return new NextResponse('Downstream service request failed', {
+    status: 500,
+  })
+}

--- a/src/mock-server/handlers/charts/subplot/fixtures/subplotChart.ts
+++ b/src/mock-server/handlers/charts/subplot/fixtures/subplotChart.ts
@@ -1,7 +1,0 @@
-export const mockSubplotChart = {
-  chart: '',
-  figure: {
-    data: [],
-    layout: {},
-  },
-}

--- a/src/mock-server/handlers/charts/subplot/fixtures/subplotChart.ts
+++ b/src/mock-server/handlers/charts/subplot/fixtures/subplotChart.ts
@@ -1,0 +1,7 @@
+export const mockSubplotChart = {
+  chart: '',
+  figure: {
+    data: [],
+    layout: {},
+  },
+}

--- a/src/mock-server/handlers/charts/subplot/v1.ts
+++ b/src/mock-server/handlers/charts/subplot/v1.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express'
+import fs from 'fs'
+import path from 'path'
+
+import { requestSchema } from '@/api/requests/charts/subplot/getSubplots'
+import { logger } from '@/lib/logger'
+
+const fixturesDirectory = path.resolve(process.cwd(), 'src/mock-server/handlers/charts/fixtures')
+const wideFixture = fs.readFileSync(path.join(fixturesDirectory, `wide.svg`))
+
+export default async function handler(req: Request, res: Response) {
+  try {
+    if (req.method !== 'POST') {
+      logger.error(`Unsupported request method ${req.method}`)
+      return res.status(405)
+    }
+
+    const parsedRequestBody = requestSchema.safeParse(req.body)
+
+    if (!parsedRequestBody.success) {
+      return res.status(500).send({
+        message: 'Error parsing request body',
+      })
+    }
+
+    return res.json({
+      chart: wideFixture.toString(),
+      alt_text: 'Mocked alt text',
+      last_updated: '2025-09-10T15:01:06.939535+01:00',
+      figure: {
+        data: [],
+        layout: {},
+      },
+    })
+  } catch (error) {
+    logger.error(error)
+    return res.status(500)
+  }
+}

--- a/src/mock-server/handlers/cms/pages/fixtures/page/vaccination-coverage.ts
+++ b/src/mock-server/handlers/cms/pages/fixtures/page/vaccination-coverage.ts
@@ -23,8 +23,24 @@ export const vaccinationCoverageMock: PageResponse<PageType.Topic> = {
       title: 'Respiratory viruses',
     },
   },
-  title: 'Childhood vaccinations',
+  title: 'Childhood vaccination coverage',
   body: [
+    {
+      type: 'section',
+      value: {
+        heading: 'Coverage map',
+        content: [
+          {
+            type: 'filter_linked_map',
+            value: {
+              title_prefix: 'Vaccination coverage statistics',
+            },
+            id: 'c5720a34-4f6e-4132-b82b-c8982b9f4551',
+          },
+        ],
+      },
+      id: 'c95a839e-4aa6-4f11-af18-c72df6623268',
+    },
     {
       type: 'section',
       value: {
@@ -80,7 +96,7 @@ export const vaccinationCoverageMock: PageResponse<PageType.Topic> = {
                               value: {
                                 label: 'Region',
                                 colour: 'COLOUR_2_TURQUOISE',
-                                geography_type: 'Lower Tier Local Authority',
+                                geography_type: 'Region',
                               },
                               id: '87c30c92-c9bd-46cd-89eb-6468e46e7b5b',
                             },
@@ -337,18 +353,45 @@ export const vaccinationCoverageMock: PageResponse<PageType.Topic> = {
     {
       type: 'section',
       value: {
-        heading: 'Coverage map',
+        heading: 'Coverage statistics',
         content: [
           {
-            type: 'filter_linked_map',
+            type: 'filter_linked_sub_plot_chart_template',
             value: {
-              title_prefix: 'Vaccination coverage statistics',
+              title_prefix: 'Vaccination coverage',
+              legend_title: 'Coverage (%)',
+              target_threshold: 95,
+              target_threshold_label: '95% target',
             },
-            id: 'c5720a34-4f6e-4132-b82b-c8982b9f4551',
+            id: 'f5aa2cb0-b871-4c71-a880-d2c1433e3618',
           },
         ],
       },
-      id: 'c95a839e-4aa6-4f11-af18-c72df6623268',
+      id: 'f5aa2cb0-b871-4c71-a880-d2c1433e3618',
+    },
+    {
+      type: 'section',
+      value: {
+        heading: 'Time series',
+        content: [
+          {
+            type: 'text_card',
+            value: {
+              body: '<p data-block-key="04bkf">Annual immunisation coverage is calculated and reported by financial year (1 April to 31 March). In time series data, coverage statistics for a given year are tied to the end of respective financial year. For example, annual coverage for the 2022-2023 reporting year is represented by the date 31 March 2023.</p><p data-block-key="dadjm">In Q2 2020-2021 the vaccine schedule changed for the pneumococcal vaccine. Coverage for this reporting year cannot be calculated. This may also affect comparability with previous years.</p>',
+            },
+            id: '4678dec2-9023-4dae-91c5-1c18d3a04d7b',
+          },
+          {
+            type: 'filter_linked_time_series_chart_template',
+            value: {
+              title_prefix: 'Vaccination coverage by year',
+              legend_title: 'Coverage (%)',
+            },
+            id: '486629f9-07ce-4f41-a4eb-413c006a8c10',
+          },
+        ],
+      },
+      id: '587c7b3a-2313-444e-87b6-d5d9c27d6ccb',
     },
   ],
   seo_change_frequency: 5,

--- a/src/mock-server/handlers/tables/subplot/fixtures/childhoodVaccines/defaultCoverageTableValues.ts
+++ b/src/mock-server/handlers/tables/subplot/fixtures/childhoodVaccines/defaultCoverageTableValues.ts
@@ -1,0 +1,64 @@
+import type { Response } from '@/api/requests/tables/subplot/getSubplotTables'
+
+export const defaultCoverageTableValues: Response = [
+  {
+    reference: 'England',
+    values: [
+      {
+        in_reporting_delay_period: false,
+        label: '6-in-1 (12 months)',
+        value: '88.0000',
+      },
+      {
+        in_reporting_delay_period: false,
+        label: '6-in-1 (24 months)',
+        value: '78.0000',
+      },
+      {
+        in_reporting_delay_period: false,
+        label: 'MMR1 (24 months)',
+        value: '84.0000',
+      },
+    ],
+  },
+  {
+    reference: 'North East',
+    values: [
+      {
+        in_reporting_delay_period: false,
+        label: '6-in-1 (12 months)',
+        value: '97.0000',
+      },
+      {
+        in_reporting_delay_period: false,
+        label: '6-in-1 (24 months)',
+        value: '89.0000',
+      },
+      {
+        in_reporting_delay_period: false,
+        label: 'MMR1 (24 months)',
+        value: '84.0000',
+      },
+    ],
+  },
+  {
+    reference: 'Darlington',
+    values: [
+      {
+        in_reporting_delay_period: false,
+        label: '6-in-1 (12 months)',
+        value: '90.0000',
+      },
+      {
+        in_reporting_delay_period: false,
+        label: '6-in-1 (24 months)',
+        value: '87.0000',
+      },
+      {
+        in_reporting_delay_period: false,
+        label: 'MMR1 (24 months)',
+        value: '93.0000',
+      },
+    ],
+  },
+]

--- a/src/mock-server/handlers/tables/subplot/fixtures/fixtures.ts
+++ b/src/mock-server/handlers/tables/subplot/fixtures/fixtures.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+import { Topics } from '@/api/models'
+import { responseSchema } from '@/api/requests/tables/subplot/getSubplotTables'
+
+import { defaultCoverageTableValues } from '.'
+
+type Fixtures = Record<Topics, z.infer<typeof responseSchema>>
+
+export const fixtures: Fixtures = {
+  immunisation: defaultCoverageTableValues,
+}

--- a/src/mock-server/handlers/tables/subplot/fixtures/index.ts
+++ b/src/mock-server/handlers/tables/subplot/fixtures/index.ts
@@ -1,0 +1,1 @@
+export * from './childhoodVaccines/defaultCoverageTableValues'

--- a/src/mock-server/handlers/tables/subplot/v1.ts
+++ b/src/mock-server/handlers/tables/subplot/v1.ts
@@ -1,0 +1,40 @@
+import { Request, Response } from 'express'
+
+import { requestSchema } from '@/api/requests/tables/subplot/getSubplotTables'
+import { logger } from '@/lib/logger'
+
+import { defaultCoverageTableValues } from '../subplot/fixtures/childhoodVaccines/defaultCoverageTableValues'
+import { fixtures } from './fixtures/fixtures'
+
+export default async function handler(req: Request, res: Response) {
+  try {
+    if (req.method !== 'POST') {
+      logger.error(`Unsupported request method: ${req.method}`)
+      return res.status(405)
+    }
+
+    const parsedRequestBody = requestSchema.safeParse(req.body)
+
+    if (!parsedRequestBody.success) {
+      return res.status(500).send({
+        message: 'Failed to parse request body',
+      })
+    }
+
+    const {
+      data: {
+        chart_parameters: { theme },
+      },
+    } = parsedRequestBody
+
+    if (theme && fixtures.hasOwnProperty(theme)) {
+      logger.info(fixtures[theme])
+      res.status(200).send(fixtures[theme])
+    }
+
+    res.status(200).send(defaultCoverageTableValues)
+  } catch (error) {
+    logger.error(error)
+    return res.status(500)
+  }
+}

--- a/src/mock-server/handlers/tables/v4.ts
+++ b/src/mock-server/handlers/tables/v4.ts
@@ -18,7 +18,9 @@ export default async function handler(req: Request, res: Response) {
 
     // Return a 500 if the query parameters provided aren't valid
     if (!parsedQueryParams.success) {
-      return res.status(500)
+      return res.status(500).send({
+        message: 'Failed to parse request body',
+      })
     }
 
     const {
@@ -28,7 +30,7 @@ export default async function handler(req: Request, res: Response) {
     } = parsedQueryParams
 
     // Return a json fixture identified by the topic & metric provided
-    if (fixtures[topic][metric]) {
+    if (fixtures[topic]?.hasOwnProperty(metric)) {
       return res.json(fixtures[topic][metric])
     }
 

--- a/src/mock-server/index.ts
+++ b/src/mock-server/index.ts
@@ -26,6 +26,7 @@ import express from 'express'
 import alertList from './handlers/alerts/v1/[category]'
 import alertDetail from './handlers/alerts/v1/[category]/[region]'
 import bulkDownloads from './handlers/bulkdownloads/v1'
+import subplotCharts from './handlers/charts/subplot/v1'
 import charts from './handlers/charts/v3'
 import pages from './handlers/cms/pages'
 import page from './handlers/cms/pages/[id]'
@@ -38,6 +39,7 @@ import headlines from './handlers/headlines/v3'
 import maps from './handlers/maps/v1/v1'
 import menus from './handlers/menus/v1'
 import suggestions from './handlers/suggestions/v2'
+import subplotTables from './handlers/tables/subplot/v1'
 import tables from './handlers/tables/v4'
 import trends from './handlers/trends/v3'
 
@@ -64,7 +66,9 @@ app.get('/api/menus/v1', menus)
 
 // POST endpoints
 app.post('/api/charts/v3', charts)
+app.post('/api/charts/subplot/v1', subplotCharts)
 app.post('/api/tables/v4', tables)
+app.post('/api/tables/subplot/v1', subplotTables)
 app.post('/api/downloads/v2', downloads)
 app.post('/api/maps/v1', maps)
 


### PR DESCRIPTION
# Description

This PR provides basic mocks for the coverage and time-series charts on the childhood vaccination page. Including an update to the page mock to bring inline with production.

Included is the implementation of both API and proxy API requests for the new subplot tables endpoint. `api/tables/subplot/v1` and `api/proxy/tables/subplot/v1` to enable development of the subplot tables component.

**Notes**:

The charts on the childhood vaccination page are client components and do not use the `static` chart used on the other topic pages.

This means the SVG image used to mock the server component charts does not work in the same way as we hand over to the interactive chart component. Currently these mocks just load empty charts (see attached screenshot), which is enough to work on tabular data and see the correct number of charts load per selected geography. There will be a follow on ticket to expand these mocks to include data.

Fixes #CDD-

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
