### PR TITLE
Replace `:alert:` with `:rotating_light:` as alert emoji is not available in the slack workspace

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -92,7 +92,7 @@ jobs:
         if: ${{ needs.smoke-tests.result == 'failure' }}
         with:
           status: failure
-          notification_title: ':x: {workflow} workflow has {status_message} :x:'
+          notification_title: ':rotating_light: {workflow} workflow has {status_message} :rotating_light:'
           message_format: '*{workflow}* {status_message} in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>'
           mention_groups: ${{ vars.SLACK_MENTION_USERS }}
           mention_groups_when: 'failure,warnings'


### PR DESCRIPTION
# Description

Since moving the alerts from the Burendo to the UKHSA slack workspace, the `:alert:` emoji is not available so it is currently being rendered as a literal string for failed smoke test runs. This PR updates the referenced icon to one that does exist in the UKHSA slack workspace

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
