### PR TITLE
CDD-1699: Replace long-lived PAT with ephemeral token to authenticate cross repo call for CD pipeline

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -256,6 +256,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Generate ephemeral deployment token
+        id: generate-deployment-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID }}
+          private-key: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_PRIVATE_KEY }}
+          skip-token-revoke: false
+          repositories: "data-dashboard-infra"
+
       - uses: ./.github/actions/trigger-deployments
         with:
-          token: ${{ secrets.DEPLOYMENT_TRIGGER_TOKEN }}
+          token: ${{ steps.generate-deployment-token.outputs.token }}


### PR DESCRIPTION
# Description

- Outside of this we have created a new Github app `data-dashboard-deployments` which has access to the dashboard repos only
- We are now using the `create-github-app-token` action to generate a token from the aforementioned Github app
- This generated token is now being used to authenticate the cross-repo call made from this repo -> infra repo (which runs the deployment workflow to deploy the latest container images)

Fixes #CDD-1699

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
