### PR TITLE
cdd-3362: Update weather alert default button type

### DIFF
--- a/src/app/(topics)/(weather-health-alerts)/weather-health-alerts/page.tsx
+++ b/src/app/(topics)/(weather-health-alerts)/weather-health-alerts/page.tsx
@@ -50,7 +50,7 @@ export default async function WeatherHealthAlerts() {
   const allowedTypes = ['heat', 'cold'] as const
   type AllowedType = (typeof allowedTypes)[number]
   const buttonType = weatherType?.value.button_type
-  const type: AllowedType = allowedTypes.includes(buttonType as AllowedType) ? (buttonType as AllowedType) : 'cold'
+  const type: AllowedType = allowedTypes.includes(buttonType as AllowedType) ? (buttonType as AllowedType) : 'heat'
   const buttonText = weatherType?.value.text || ''
 
   return (


### PR DESCRIPTION
# Description

This PR updates the default button type for WHA to heat, the integration of the weather health alert button isn't complete and current we default to `cold`, with the change to the `heat` alert season this will update the default button type ahead of completing integration with the CMS.

Fixes #CDD-3362

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
