### PR TITLE
chore: update slack action dependency to v2.5.0

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: 'Report Success'
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
         if: ${{ needs.smoke-tests.result == 'success' }}
         with:
           status: success
@@ -57,7 +57,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: 'Report Failure'
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
         if: ${{ needs.smoke-tests.result == 'failure' }}
         with:
           status: failure


### PR DESCRIPTION
Noticed that a [smoke test run failed](https://github.com/UKHSA-Internal/data-dashboard-frontend/actions/runs/26524364875/job/78124291671) even though others had succeeded on the same day and figured updating the slack notification action we're using couldn't hurt.