### PR TITLE
Update actions node runtime [cdd-3229]

### DIFF
--- a/.github/actions/build-cache/action.yml
+++ b/.github/actions/build-cache/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache builds
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
       id: build-cache
       with:
         path: |

--- a/.github/actions/install-cache/action.yml
+++ b/.github/actions/install-cache/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
       id: cache-dependencies
       with:
         path: |

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419
 
     - name: Build, tag, and push image to AWS ECR
       env:

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -20,7 +20,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -29,7 +29,7 @@ runs:
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ env.AWS_REGION }}

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -26,7 +26,7 @@ runs:
       uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -23,7 +23,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: '22.13.1'
         cache: 'npm'

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
     needs: [secret-scan]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/install-cache
       - name: Install
@@ -55,7 +55,7 @@ jobs:
     needs: [install]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
       - uses: ./.github/actions/build-cache
       - name: Build
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     if: false # Temporarily disabled due to config overriding CLI params and running against production
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
       - uses: ./.github/actions/build-cache
       - name: Start mock server
@@ -100,7 +100,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
       - uses: ./.github/actions/build-cache
       - name: Quality check
@@ -115,7 +115,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
       - uses: ./.github/actions/build-cache
       - name: TypeScript Compilation
@@ -131,7 +131,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
       - uses: ./.github/actions/build-cache
       - name: Unit tests
@@ -157,7 +157,7 @@ jobs:
       matrix:
         shard: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
       - uses: ./.github/actions/build-cache
 
@@ -218,7 +218,7 @@ jobs:
   #     matrix:
   #       shard: [1, 2, 3]
   #   steps:
-  #     - uses: actions/checkout@v3
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
   #     - uses: ./.github/actions/install-cache
   #     - uses: ./.github/actions/build-cache
 
@@ -263,7 +263,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Build Docker image
         run: docker build -t fe-test .
@@ -311,7 +311,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Build and publish docker image
         uses: ./.github/actions/publish-image
         with:
@@ -332,7 +332,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Generate ephemeral deployment token
         id: generate-deployment-token

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -83,7 +83,7 @@ jobs:
         run: NODE_ENV=test npm run start &
       - name: Unlighthouse assertions and client
         run: npx unlighthouse-ci --build-static --site http://localhost:3000/ --budget=80
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: unlighthouse-report
@@ -191,7 +191,7 @@ jobs:
         env:
           baseURL: http://localhost:3000
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-${{ matrix.shard }}_${{ strategy.job-total }}
@@ -247,7 +247,7 @@ jobs:
   #     - name: Run Playwright tests
   #       run: npx playwright test --grep-invert @smoke --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
-  #     - uses: actions/upload-artifact@v4
+  #     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
   #       if: ${{ !cancelled() }}
   #       with:
   #         name: playwright-report-non-public${{ matrix.shard }}_${{ strategy.job-total }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Generate ephemeral deployment token
         id: generate-deployment-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID }}
           private-key: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_PRIVATE_KEY }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -33,7 +33,7 @@ jobs:
     name: Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/install-cache
       - name: Install
@@ -44,7 +44,7 @@ jobs:
     needs: [install]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set environment URL
         id: set-url
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: 'Report Success'
         uses: ravsamhq/notify-slack-action@v1

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Unlighthouse assertions and client
         run: npx unlighthouse-ci --build-static --site ${{ env.TARGET_URL }} --budget=80
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: unlighthouse-report

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: 'Report Success'
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
         if: ${{ needs.lighthouse.result == 'success' }}
         with:
           status: success
@@ -100,7 +100,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: 'Report Failure'
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
         if: ${{ needs.lighthouse.result == 'failure' }}
         with:
           status: failure

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/install-cache
       - name: Install packages
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: 'Report Success'
         uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -30,7 +30,7 @@ jobs:
         run:  npx playwright test --grep @smoke
         env:
           baseURL: https://ukhsa-dashboard.data.gov.uk
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           name: playwright-report-smoke


### PR DESCRIPTION
Upgrade as many action dependencies as we can to remove node 20 deprecation warnings. E.g. https://github.com/UKHSA-Internal/data-dashboard-frontend/actions/runs/26668429575 which looks like this:

<img width="1472" height="756" alt="image" src="https://github.com/user-attachments/assets/131fb218-8cda-4440-9e58-20b2d88bc4ee" />

Git leaks is still lacking node 20 support (e.g. https://github.com/gitleaks/gitleaks-action/issues/209) however it does work when running against node 24 (this has been tested [here](https://github.com/UKHSA-Internal/data-dashboard-api/actions/runs/26645443353). If it becomes an issue in the future, we'll turn it off / look for another way of running it.

`ukhsa-internal/jest-coverage-comment-action@v1` is super old and needs to be updated or better yet probably removed. It does work with node 24 though so we'll deal with that outside of this ticket (tested [here](https://github.com/UKHSA-Internal/data-dashboard-infra/actions/runs/26748642117/job/78830752564)).

Note that every action has been upgraded to the latest version available but we use the sha of the commit that was released for [security reasons](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). This is also ensures we pass the sonarqube checks.

Fixes #CDD-3229

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Tech debt item (this is focused solely on addressing any relevant technical debt)
