### PR TITLE
CDD-3441 Filter null pages

### DIFF
--- a/src/api/models/cms/Page/Body.ts
+++ b/src/api/models/cms/Page/Body.ts
@@ -335,6 +335,7 @@ export const CompositeBody = z.array(
             title: z.string(),
             sub_title: z.string(),
             page: z.string(),
+            is_authorised: z.boolean().optional(),
           }),
           id: z.string(),
         }).nullable()

--- a/src/api/models/cms/Page/Body.ts
+++ b/src/api/models/cms/Page/Body.ts
@@ -337,7 +337,7 @@ export const CompositeBody = z.array(
             page: z.string(),
           }),
           id: z.string(),
-        })
+        }).nullable()
       ),
       id: z.string(),
     }),

--- a/src/api/models/cms/Page/Body.ts
+++ b/src/api/models/cms/Page/Body.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { ChartLineColours } from '@/api/models/Chart'
+import { DataClassification } from '@/api/models/DataClassification'
 
 import { HealthAlertTypes } from '../../Alerts'
 import { Blocks, HeadlineNumber, TrendNumber } from './Blocks'
@@ -336,6 +337,7 @@ export const CompositeBody = z.array(
             sub_title: z.string(),
             page: z.string(),
             is_authorised: z.boolean().optional(),
+            page_classification: DataClassification.optional(),
           }),
           id: z.string(),
         }).nullable()

--- a/src/api/models/cms/Page/Body.ts
+++ b/src/api/models/cms/Page/Body.ts
@@ -337,7 +337,7 @@ export const CompositeBody = z.array(
             sub_title: z.string(),
             page: z.string(),
             is_authorised: z.boolean().optional(),
-            page_classification: DataClassification.optional(),
+            page_classification: DataClassification.nullable().optional(),
           }),
           id: z.string(),
         }).nullable()

--- a/src/app/components/ui/ukhsa/ClassificationBanner/ClassificationBanner.tsx
+++ b/src/app/components/ui/ukhsa/ClassificationBanner/ClassificationBanner.tsx
@@ -34,8 +34,11 @@ const ClassificationBanner: FC<ClassificationBannerProps> = ({
   customContent,
   customColor,
 }) => {
+  const Wrapper = size === 'small' ? 'span' : 'div'
+  const Content = size === 'small' ? 'span' : 'p'
+
   return (
-    <div
+    <Wrapper
       className={clsx('govuk-classification-banner', {
         [customColor || levelColors[level]]: true,
         'my-3': size === 'large',
@@ -43,17 +46,17 @@ const ClassificationBanner: FC<ClassificationBannerProps> = ({
       role="note"
       aria-label={`${levelContent[level]} classification`}
     >
-      <p
+      <Content
         // eslint-disable-next-line tailwindcss/no-custom-classname
         className={clsx('font-open-sans font-bold uppercase text-white', {
           'govuk-width-container text-[27px] py-2 ml-4': size === 'large',
           'py-1 !pl-[12px] text-[18px]': size === 'medium',
-          'py-1 px-2 text-[14px]': size === 'small',
+          'inline-block py-1 px-2 text-[14px]': size === 'small',
         })}
       >
         {customContent || levelContent[level]}
-      </p>
-    </div>
+      </Content>
+    </Wrapper>
   )
 }
 export default ClassificationBanner

--- a/src/app/components/ui/ukhsa/ClassificationBanner/ClassificationBanner.tsx
+++ b/src/app/components/ui/ukhsa/ClassificationBanner/ClassificationBanner.tsx
@@ -48,6 +48,7 @@ const ClassificationBanner: FC<ClassificationBannerProps> = ({
         className={clsx('font-open-sans font-bold uppercase text-white', {
           'govuk-width-container text-[27px] py-2 ml-4': size === 'large',
           'py-1 !pl-[12px] text-[18px]': size === 'medium',
+          'py-1 px-2 text-[14px]': size === 'small',
         })}
       >
         {customContent || levelContent[level]}

--- a/src/app/utils/cms.utils.spec.tsx
+++ b/src/app/utils/cms.utils.spec.tsx
@@ -237,6 +237,7 @@ describe('renderCompositeBlock function', () => {
               title: 'COVID-19',
               sub_title: 'COVID-19 is a respiratory infection caused by the SARS-CoV-2-virus.',
               page: 'http://localhost:3000/topics/covid-19/',
+              is_authorised: true,
             },
             id: 'c36d19c1-3a5e-4fcf-b696-91468c609369',
           },

--- a/src/app/utils/cms.utils.spec.tsx
+++ b/src/app/utils/cms.utils.spec.tsx
@@ -249,6 +249,31 @@ describe('renderCompositeBlock function', () => {
     expect(screen.getByText('COVID-19 is a respiratory infection caused by the SARS-CoV-2-virus.')).toBeInTheDocument()
   })
 
+  test('does not render unauthorised internal page links', () => {
+    render(
+      renderCompositeBlock({
+        type: 'internal_page_links',
+        value: [
+          {
+            type: 'page_link',
+            value: {
+              title: 'Hidden Page',
+              sub_title: 'Should not show',
+              page: 'http://localhost:3000/hidden/',
+              is_authorised: false,
+            },
+            id: '123',
+          },
+        ],
+        id: 'block-1',
+      })
+    )
+
+    expect(
+      screen.queryByRole('link', { name: 'Hidden Page' })
+    ).not.toBeInTheDocument()
+  })
+
   test('renders code block correctly', () => {
     render(
       renderCompositeBlock({

--- a/src/app/utils/cms.utils.spec.tsx
+++ b/src/app/utils/cms.utils.spec.tsx
@@ -261,6 +261,7 @@ describe('renderCompositeBlock function', () => {
               sub_title: 'Should not show',
               page: 'http://localhost:3000/hidden/',
               is_authorised: false,
+              page_classification: 'official_sensitive'
             },
             id: '123',
           },

--- a/src/app/utils/cms.utils.tsx
+++ b/src/app/utils/cms.utils.tsx
@@ -6,6 +6,7 @@ import { z } from 'zod'
 import { Body, CardTypes, CompositeBody } from '@/api/models/cms/Page'
 import { Blocks } from '@/api/models/cms/Page/Blocks'
 import { DataClassification } from '@/api/models/DataClassification'
+import ClassificationBanner from '@/app/components/ui/ukhsa/ClassificationBanner/ClassificationBanner'
 import { List } from '@/app/components/ui/ukhsa/List/List'
 import { ListItemArrow, ListItemArrowLink, ListItemArrowParagraph } from '@/app/components/ui/ukhsa/List/ListItemArrow'
 import { getPath } from '@/app/utils/cms/slug'
@@ -251,7 +252,15 @@ export const renderCompositeBlock = ({ id, type, value }: CompositeBody[number])
             <ListItem key={id} spacing="m">
               <ListItemArrow>
                 <ListItemArrowLink href={getPath(value.page)}>
-                  {value.title}
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
+                    {value.title}
+                    {value.page_classification && (
+                      <ClassificationBanner
+                        size="small"
+                        level={value.page_classification}
+                      />
+                    )}
+                  </span>
                 </ListItemArrowLink>
                 <ListItemArrowParagraph>
                   {value.sub_title}

--- a/src/app/utils/cms.utils.tsx
+++ b/src/app/utils/cms.utils.tsx
@@ -235,18 +235,37 @@ export const renderCompositeBlock = ({ id, type, value }: CompositeBody[number])
       />
     )}
 
-    {type === 'internal_page_links' && value && value.length > 0 && (
-      <List>
-        <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-        {value.map(({ id, value }) => (
-          <ListItem key={id} spacing="m">
-            <ListItemArrow>
-              <ListItemArrowLink href={getPath(value.page)}>{value.title}</ListItemArrowLink>
-              <ListItemArrowParagraph>{value.sub_title}</ListItemArrowParagraph>
-            </ListItemArrow>
-          </ListItem>
-        ))}
-      </List>
-    )}
+    {type === 'internal_page_links' && (() => {
+      const authorisedLinks =
+        value?.filter(
+          (link): link is NonNullable<typeof link> =>
+            Boolean(
+              link &&
+              link.value &&
+              link.value.title?.trim() !== "" &&
+              link.value.page
+            )
+        ) ?? [];
+
+      if (authorisedLinks.length === 0) return null;
+
+      return (
+        <List>
+          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+          {authorisedLinks.map(({ id, value }) => (
+            <ListItem key={id} spacing="m">
+              <ListItemArrow>
+                <ListItemArrowLink href={getPath(value.page)}>
+                  {value.title}
+                </ListItemArrowLink>
+                <ListItemArrowParagraph>
+                  {value.sub_title}
+                </ListItemArrowParagraph>
+              </ListItemArrow>
+            </ListItem>
+          ))}
+        </List>
+      );
+    })()}
   </Fragment>
 )

--- a/src/app/utils/cms.utils.tsx
+++ b/src/app/utils/cms.utils.tsx
@@ -239,12 +239,7 @@ export const renderCompositeBlock = ({ id, type, value }: CompositeBody[number])
       const authorisedLinks =
         value?.filter(
           (link): link is NonNullable<typeof link> =>
-            Boolean(
-              link &&
-              link.value &&
-              link.value.title?.trim() !== "" &&
-              link.value.page
-            )
+            !!link?.value?.is_authorised
         ) ?? [];
 
       if (authorisedLinks.length === 0) return null;


### PR DESCRIPTION
# Description

This is the corresponding PR to the backend changes [here](https://github.com/UKHSA-Internal/data-dashboard-api/pull/3260).

It allows null pages to be filtered out of the get pages response and removes the formatting so there isn't an empty block.

Fixes #[CDD-3441](https://ukhsa.atlassian.net/browse/CDD-3441) (AC2, 3 & 4)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


[CDD-3441]: https://ukhsa.atlassian.net/browse/CDD-3441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ