### PR TITLE
CDD-3509

### DIFF
--- a/src/app/components/ui/ukhsa/Scripts/BFCacheReloadHandler/BFCacheReloadHandler.spec.tsx
+++ b/src/app/components/ui/ukhsa/Scripts/BFCacheReloadHandler/BFCacheReloadHandler.spec.tsx
@@ -1,0 +1,66 @@
+import { render } from '@/config/test-utils'
+
+import { BFCacheReloadHandler } from './BFCacheReloadHandler'
+
+describe('BFCacheReloadHandler', () => {
+  let addEventListenerSpy: jest.SpyInstance
+  let removeEventListenerSpy: jest.SpyInstance
+  let reloadMock: jest.Mock
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+    removeEventListenerSpy = jest.spyOn(window, 'removeEventListener')
+    reloadMock = jest.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadMock },
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('renders nothing', () => {
+    const { container } = render(<BFCacheReloadHandler />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('registers a pageshow listener on mount', () => {
+    render(<BFCacheReloadHandler />)
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('pageshow', expect.any(Function))
+  })
+
+  it('removes the pageshow listener on unmount', () => {
+    const { unmount } = render(<BFCacheReloadHandler />)
+
+    const registeredHandler = addEventListenerSpy.mock.calls.find(([eventName]) => eventName === 'pageshow')?.[1]
+
+    unmount()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('pageshow', registeredHandler)
+  })
+
+  it('reloads the page when pageshow fires with persisted=true (BFCache restore)', () => {
+    render(<BFCacheReloadHandler />)
+
+    const event = new Event('pageshow') as PageTransitionEvent
+    Object.defineProperty(event, 'persisted', { value: true })
+
+    window.dispatchEvent(event)
+
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reload the page when pageshow fires with persisted=false (normal navigation)', () => {
+    render(<BFCacheReloadHandler />)
+
+    const event = new Event('pageshow') as PageTransitionEvent
+    Object.defineProperty(event, 'persisted', { value: false })
+
+    window.dispatchEvent(event)
+
+    expect(reloadMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/components/ui/ukhsa/Scripts/BFCacheReloadHandler/BFCacheReloadHandler.tsx
+++ b/src/app/components/ui/ukhsa/Scripts/BFCacheReloadHandler/BFCacheReloadHandler.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function BFCacheReloadHandler() {
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        window.location.reload()
+      }
+    }
+    window.addEventListener('pageshow', handlePageShow)
+    return () => window.removeEventListener('pageshow', handlePageShow)
+  }, [])
+
+  return null
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,11 +17,11 @@ import { Footer } from './components/ui/govuk'
 import { CookieBanner } from './components/ui/ukhsa'
 import LogoutWarning from './components/ui/ukhsa/LogoutWarning/LogoutWarning'
 import { HealthAlertsMapWrapper } from './components/ui/ukhsa/Map/health-alerts/HealthAlertsMapWrapper'
+import { BFCacheReloadHandler } from './components/ui/ukhsa/Scripts/BFCacheReloadHandler/BFCacheReloadHandler'
 import { GoogleTagManager } from './components/ui/ukhsa/Scripts/GoogleTagManager/GoogleTagManager'
 import { GovUK } from './components/ui/ukhsa/Scripts/GovUK/GovUK'
 import { UKHSA_GDPR_COOKIE_NAME } from './constants/cookies.constants'
 import { Providers } from './providers'
-
 export const dynamic = 'auto'
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -48,6 +48,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             />
           </Suspense>
           {accessToken && <LogoutWarning />}
+          <BFCacheReloadHandler />
           <Providers>
             {children}
             <HealthAlertsMapWrapper />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -48,7 +48,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             />
           </Suspense>
           {accessToken && <LogoutWarning />}
-          <BFCacheReloadHandler />
+          {accessToken && <BFCacheReloadHandler />}
           <Providers>
             {children}
             <HealthAlertsMapWrapper />


### PR DESCRIPTION
Add a pageshow listener to force a reload on BFCache restore and redirect unauthorized users to the Not Found page

# Description


- Added a pageshow event listener to detect when a page is restored from the Back/Forward Cache (BFCache).
- Forced a page reload on BFCache restore to ensure the user's authentication and authorization state is revalidated.
- Redirected users without the required permissions to the Not Found page after the session is revalidated.
- Prevents users from viewing stale or unauthorized content when navigating back after signing out or when their permissions have changed.


Fixes #CDD-3509

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [x] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
