### PR TITLE
CDD-3489: Updating map colours, hex only

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -84,27 +84,27 @@ $govuk-font-family: var(--font-primary), arial, sans-serif;
 
   // Extended Map Colours - introduced as part of the COVER work
   // Solid colors (alpha: 1)
-  --colour-map-dark-blue: rgba(8, 104, 172, 1);
-  --colour-map-turquoise: rgba(123, 204, 196, 1);
-  --colour-map-blue: rgba(67, 162, 202, 1);
-  --colour-map-light-green: rgba(186, 228, 188, 1);
   --colour-map-light-yellow: rgba(240, 249, 232, 1);
+  --colour-map-light-green: rgba(161, 218, 180, 1);
+  --colour-map-turquoise: rgba(65, 182, 196, 1);
+  --colour-map-blue: rgba(44, 127, 184, 1);
+  --colour-map-dark-blue: rgba(37, 52, 148, 1);
   --colour-map-white: rgba(255, 255, 255, 1);
 
   // semi-transparent colors (alpha: 0.5)
-  --colour-map-dark-blue-semi: rgba(8, 104, 172, 0.5);
-  --colour-map-turquoise-semi: rgba(123, 204, 196, 0.5);
-  --colour-map-blue-semi: rgba(67, 162, 202, 0.5);
-  --colour-map-light-green-semi: rgba(186, 228, 188, 0.5);
   --colour-map-light-yellow-semi: rgba(240, 249, 232, 0.5);
+  --colour-map-light-green-semi: rgba(161, 218, 180, 0.5);
+  --colour-map-turquoise-semi: rgba(65, 182, 196, 0.5);
+  --colour-map-blue-semi: rgba(44, 127, 184, 0.5);
+  --colour-map-dark-blue-semi: rgba(37, 52, 148, 0.5);
   --colour-map-white-semi: rgba(255, 255, 255, 0.5);
 
   // hover colours (alpha:0.75)
-  --colour-map-dark-blue-hover: rgba(8, 104, 172, 0.75);
-  --colour-map-turquoise-hover: rgba(123, 204, 196, 0.75);
-  --colour-map-blue-hover: rgba(67, 162, 202, 0.75);
-  --colour-map-light-green-hover: rgba(186, 228, 188, 0.75);
   --colour-map-light-yellow-hover: rgba(240, 249, 232, 0.75);
+  --colour-map-light-green-hover: rgba(161, 218, 180, 0.75);
+  --colour-map-turquoise-hover: rgba(65, 182, 196, 0.75);
+  --colour-map-blue-hover: rgba(44, 127, 184, 0.75);
+  --colour-map-dark-blue-hover: rgba(37, 52, 148, 0.75);
   --colour-map-white-hover: rgba(255, 255, 255, 0.75);
 
   // Govuk greys


### PR DESCRIPTION
# Description

Updating hex colours for map key

Fixes #CDD-3489

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Unit tests
- [ ] Playwright e2e tests
- [ ] Mobile responsiveness
- [ ] Accessibility (i.e. Lighthouse audit)
- [ ] Disabled JavaScript

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
