### PR TITLE
CDD-3501: Send classification metadata for dual category chart requests

### DIFF
--- a/src/api/requests/charts/getCharts.spec.ts
+++ b/src/api/requests/charts/getCharts.spec.ts
@@ -293,6 +293,8 @@ describe('getDualCategoryCharts', () => {
     primary_field_values: ['2024-01-01'],
     secondary_category: 'age',
     segments: [{ secondary_field_value: '0-4', colour: 'COLOUR_1_DARK_BLUE' }],
+    is_public: false,
+    data_classification: 'official_sensitive',
   }
 
   const mockResponseData = {
@@ -313,6 +315,16 @@ describe('getDualCategoryCharts', () => {
 
     expect(result.success).toBe(true)
     expect(result.data?.chart).toBe('mock-chart-svg')
+    expect(client).toHaveBeenCalledWith(
+      'proxy/charts/dual-category/v1',
+      {
+        body: expect.objectContaining({
+          is_public: false,
+          data_classification: 'official_sensitive',
+        }),
+      },
+      false
+    )
   })
 
   test('logs validation error and returns failed parse when response data is invalid', async () => {

--- a/src/api/requests/charts/getDualCategoryCharts.ts
+++ b/src/api/requests/charts/getDualCategoryCharts.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import { Geography, GeographyType, Metrics, Topics } from '@/api/models'
 import { ChartFigure, ChartLineColours, ChartTypes } from '@/api/models/Chart'
+import { DataClassification } from '@/api/models/DataClassification'
 import { client } from '@/api/utils/api.utils'
 import { isSSR } from '@/app/utils/app.utils'
 import { chartFormat } from '@/config/constants'
@@ -29,6 +30,8 @@ export const requestSchema = z.object({
   y_axis_title: z.string().optional(),
   y_axis_minimum_value: z.number().nullable().optional(),
   y_axis_maximum_value: z.number().nullable().optional(),
+  is_public: z.boolean(),
+  data_classification: DataClassification.optional(),
   chart_type: ChartTypes,
   static_fields: staticFieldsSchema,
   primary_field_values: z.array(z.string()),
@@ -60,7 +63,7 @@ export const getDualCategoryCharts = async (chart: RequestParams) => {
 
   try {
     const path = isSSR ? `charts/dual-category/v1` : `proxy/charts/dual-category/v1`
-    const { data } = await client<z.infer<typeof responseSchema>>(path, { body })
+    const { data } = await client<z.infer<typeof responseSchema>>(path, { body }, chart.is_public)
 
     const result = responseSchema.safeParse(data)
     if (result.success) {

--- a/src/app/utils/chart.utils.ts
+++ b/src/app/utils/chart.utils.ts
@@ -206,7 +206,9 @@ export const getDualCategoryChartsResponseData = async (
   data: DualCategoryChartCardValue,
   selectedSize: ChartSizes[number],
   areaType: string | null,
-  areaName: string | null
+  areaName: string | null,
+  isPublic: boolean = true,
+  dataClassification?: DataClassification
 ) => {
   return await getDualCategoryCharts({
     chart_type: data.chart_type,
@@ -226,6 +228,8 @@ export const getDualCategoryChartsResponseData = async (
     y_axis_maximum_value: data.y_axis_maximum_value,
     chart_width: chartSizes[selectedSize.size].width,
     chart_height: chartSizes[selectedSize.size].height,
+    is_public: isPublic,
+    data_classification: dataClassification,
   })
 }
 
@@ -271,7 +275,7 @@ export const getFilteredChartResponseData = async (
 ) => {
   if (isDualCategoryChartCardValue(data)) {
     const filteredData = getFilteredDualCategoryData(data, filter, lastUpdated)
-    return getDualCategoryChartsResponseData(filteredData, filterNarrowSize, null, null)
+    return getDualCategoryChartsResponseData(filteredData, filterNarrowSize, null, null, isPublic, dataClassification)
   }
 
   const filteredChart = getFilteredSingleCategoryData(data, filter, lastUpdated)
@@ -295,7 +299,7 @@ export const getChartResponseData = async (
 
   // If the chart is a dual category chart, get the data and return early
   if (isDualCategoryChartCardValue(data)) {
-    return await getDualCategoryChartsResponseData(data, selectedSize, areaType, areaName)
+    return await getDualCategoryChartsResponseData(data, selectedSize, areaType, areaName, isPublic, dataClassification)
   }
 
   // Otherwise, get plots and return single category chart data


### PR DESCRIPTION
# Description

This updates the frontend dual category chart request contract to include:
- `is_public`
- `data_classification`

The dual category chart request now sends those fields to the API and passes `is_public` into the shared API client, matching the single category chart behaviour.

The chart utility helpers also now forward page classification metadata for both standard and filtered dual category chart requests.

## Why

Dual category chart image requests were not sending classification metadata, so the backend could not apply the OFFICIAL-SENSITIVE watermark for non-public chart exports.

Singe category chart requests already do this, so this brings dual category charts in line with the existing contract.

Fixes #CDD-3501

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Unit tests
- [ ] Playwright e2e tests

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Any styles in this change follow the 'STYLES.md' guide
- [ ] My changes are progressively enhanced with graceful degredagation for older browsers and non-JavaScript users
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
